### PR TITLE
MSTR-177 : Github email 조회 불가능 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
 
 val snippetsDir by extra { file("build/generated-snippets") }
 val querydslVersion = "5.0.0"
+extra["springCloudVersion"] = "2021.0.3"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -68,6 +69,13 @@ dependencies {
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8")
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+    }
 }
 
 idea {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -326,8 +326,8 @@ include::{snippets}/users/findAll/response-fields.adoc[]
 ----
 유저 정보 수정을 위한 API입니다.
 
-HTTP Method : PATCH
-End-Point   : /api/v1/users
+HTTP Method : PUT
+End-Point   : /api/v1/users/{userID: UUID}
 ----
 
 .Sample Request

--- a/src/main/kotlin/com/csbroker/apiserver/ApiServerApplication.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/ApiServerApplication.kt
@@ -3,11 +3,13 @@ package com.csbroker.apiserver
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
+@EnableFeignClients
 class ApiServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/csbroker/apiserver/common/auth/GithubOAuth2UserInfo.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/auth/GithubOAuth2UserInfo.kt
@@ -9,7 +9,7 @@ class GithubOAuth2UserInfo(
     }
 
     override fun getName(): String {
-        return attributes["name"] as String
+        return attributes["login"] as String
     }
 
     override fun getEmail(): String {

--- a/src/main/kotlin/com/csbroker/apiserver/common/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/config/security/SecurityConfig.kt
@@ -11,6 +11,7 @@ import com.csbroker.apiserver.common.handler.OAuth2AuthenticationSuccessHandler
 import com.csbroker.apiserver.common.handler.TokenAccessDeniedHandler
 import com.csbroker.apiserver.repository.OAuth2AuthorizationRequestBasedOnCookieRepository
 import com.csbroker.apiserver.repository.RedisRepository
+import com.csbroker.apiserver.repository.UserRepository
 import com.csbroker.apiserver.service.CustomOAuth2UserService
 import com.csbroker.apiserver.service.CustomUserDetailsService
 import org.springframework.context.annotation.Bean
@@ -41,7 +42,8 @@ class SecurityConfig(
     private val userDetailsService: CustomUserDetailsService,
     private val oAuth2UserService: CustomOAuth2UserService,
     private val redisRepository: RedisRepository,
-    private val tokenAccessDeniedHandler: TokenAccessDeniedHandler
+    private val tokenAccessDeniedHandler: TokenAccessDeniedHandler,
+    private val userRepository: UserRepository
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -123,7 +125,8 @@ class SecurityConfig(
             appProperties,
             oAuth2AuthorizationRequestBasedOnCookieRepository(),
             authTokenProvider,
-            redisRepository
+            redisRepository,
+            userRepository
         )
     }
 

--- a/src/main/kotlin/com/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
@@ -88,7 +88,7 @@ class OAuth2AuthenticationSuccessHandler(
             Date(now.time + refreshTokenExpiry)
         )
 
-        redisRepository.setRefreshTokenByEmail(userInfo.getEmail(), refreshToken.token)
+        redisRepository.setRefreshTokenByEmail(findUser.email, refreshToken.token)
 
         val cookieMaxAge = refreshTokenExpiry / 1000
 

--- a/src/main/kotlin/com/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
@@ -4,7 +4,6 @@ import com.csbroker.apiserver.common.auth.AuthTokenProvider
 import com.csbroker.apiserver.common.auth.OAuth2UserInfoFactory
 import com.csbroker.apiserver.common.auth.ProviderType
 import com.csbroker.apiserver.common.config.properties.AppProperties
-import com.csbroker.apiserver.common.enums.Role
 import com.csbroker.apiserver.common.util.addCookie
 import com.csbroker.apiserver.common.util.deleteCookie
 import com.csbroker.apiserver.common.util.getCookie
@@ -12,6 +11,7 @@ import com.csbroker.apiserver.repository.OAuth2AuthorizationRequestBasedOnCookie
 import com.csbroker.apiserver.repository.REDIRECT_URI_PARAM_COOKIE_NAME
 import com.csbroker.apiserver.repository.REFRESH_TOKEN
 import com.csbroker.apiserver.repository.RedisRepository
+import com.csbroker.apiserver.repository.UserRepository
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
@@ -30,7 +30,8 @@ class OAuth2AuthenticationSuccessHandler(
     private val appProperties: AppProperties,
     private val authorizationRequestRepository: OAuth2AuthorizationRequestBasedOnCookieRepository,
     private val tokenProvider: AuthTokenProvider,
-    private val redisRepository: RedisRepository
+    private val redisRepository: RedisRepository,
+    private val userRepository: UserRepository
 ) : SimpleUrlAuthenticationSuccessHandler() {
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
@@ -68,22 +69,22 @@ class OAuth2AuthenticationSuccessHandler(
 
         val user = authentication.principal as OidcUser
         val userInfo = OAuth2UserInfoFactory.getOauth2UserInfo(providerType, user.attributes)
-        val authorities = user.authorities
 
-        val roleType = if (this.hasAuthority(authorities, Role.ROLE_ADMIN.code)) Role.ROLE_ADMIN else Role.ROLE_USER
+        val findUser = this.userRepository.findUserByProviderId(userInfo.getId())
+            ?: throw IllegalArgumentException("")
 
         val now = Date()
         val tokenExpiry = appProperties.auth.tokenExpiry
         val refreshTokenExpiry = appProperties.auth.refreshTokenExpiry
 
         val accessToken = tokenProvider.createAuthToken(
-            userInfo.getEmail(),
+            findUser.email,
             Date(now.time + tokenExpiry),
-            roleType.code
+            findUser.role.code
         )
 
         val refreshToken = tokenProvider.createAuthToken(
-            userInfo.getEmail(),
+            findUser.email,
             Date(now.time + refreshTokenExpiry)
         )
 

--- a/src/main/kotlin/com/csbroker/apiserver/common/util/GithubClient.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/util/GithubClient.kt
@@ -1,0 +1,13 @@
+package com.csbroker.apiserver.common.util
+
+import com.csbroker.apiserver.dto.user.GithubEmailResponseDto
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+
+@FeignClient(name = "github", url = "https://api.github.com")
+interface GithubClient {
+
+    @GetMapping("/user/emails")
+    fun getUserEmail(@RequestHeader(HEADER_AUTHORIZATION) accessToken: String): List<GithubEmailResponseDto>
+}

--- a/src/main/kotlin/com/csbroker/apiserver/controller/AuthController.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/controller/AuthController.kt
@@ -7,8 +7,8 @@ import com.csbroker.apiserver.common.util.deleteCookie
 import com.csbroker.apiserver.dto.ApiResponse
 import com.csbroker.apiserver.dto.UpsertSuccessResponseDto
 import com.csbroker.apiserver.dto.auth.TokenResponseDto
-import com.csbroker.apiserver.dto.user.UserLoginRequestDto
 import com.csbroker.apiserver.dto.user.UserInfoResponseDto
+import com.csbroker.apiserver.dto.user.UserLoginRequestDto
 import com.csbroker.apiserver.dto.user.UserSignUpDto
 import com.csbroker.apiserver.repository.REFRESH_TOKEN
 import com.csbroker.apiserver.service.AuthService

--- a/src/main/kotlin/com/csbroker/apiserver/controller/UserController.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/controller/UserController.kt
@@ -8,8 +8,8 @@ import com.csbroker.apiserver.service.UserService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -41,7 +41,7 @@ class UserController(
         return ApiResponse.success(result)
     }
 
-    @PatchMapping("/{id}")
+    @PutMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN', 'USER', 'BUSINESS')")
     fun updateUser(
         @LoginUser loginUser: User,

--- a/src/main/kotlin/com/csbroker/apiserver/dto/user/GithubEmailResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/user/GithubEmailResponseDto.kt
@@ -1,0 +1,8 @@
+package com.csbroker.apiserver.dto.user
+
+data class GithubEmailResponseDto(
+    val email: String,
+    val verified: Boolean,
+    val primary: Boolean,
+    val visibility: String?
+)

--- a/src/main/kotlin/com/csbroker/apiserver/model/User.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/User.kt
@@ -42,6 +42,9 @@ class User(
     @Column(name = "provider_type")
     var providerType: ProviderType,
 
+    @Column(name = "provider_id")
+    var providerId: String? = null,
+
     @Column(name = "profile_image", columnDefinition = "TEXT")
     var profileImageUrl: String? = null,
 

--- a/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
@@ -8,6 +8,6 @@ import java.util.UUID
 interface UserRepository : JpaRepository<User, UUID> {
     fun findByEmail(email: String): User?
     fun findByEmailOrUsername(email: String, username: String): User?
-
     fun findUsersByRole(role: Role): List<User>
+    fun findUserByProviderId(providerId: String): User?
 }

--- a/src/main/kotlin/com/csbroker/apiserver/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/AuthServiceImpl.kt
@@ -2,6 +2,7 @@ package com.csbroker.apiserver.service
 
 import com.csbroker.apiserver.common.auth.AUTHORITIES_KEY
 import com.csbroker.apiserver.common.auth.AuthTokenProvider
+import com.csbroker.apiserver.common.auth.ProviderType
 import com.csbroker.apiserver.common.config.properties.AppProperties
 import com.csbroker.apiserver.common.enums.Role
 import com.csbroker.apiserver.common.util.getAccessToken
@@ -56,6 +57,10 @@ class AuthServiceImpl(
 
         val findUser = userRepository.findByEmail(email)
             ?: throw IllegalArgumentException("존재하지 않는 이메일입니다. $email")
+
+        if (findUser.providerType != ProviderType.LOCAL) {
+            throw IllegalArgumentException("${findUser.providerType} 를 통해 가입한 계정입니다.")
+        }
 
         if (!passwordEncoder.matches(rawPassword, findUser.password)) {
             throw IllegalArgumentException("비밀번호가 일치하지 않습니다!")

--- a/src/main/kotlin/com/csbroker/apiserver/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/CustomOAuth2UserService.kt
@@ -41,8 +41,6 @@ class CustomOAuth2UserService(
 
         val attributes = user.attributes.toMutableMap()
 
-        println(attributes)
-
         if (providerType == ProviderType.GITHUB && attributes["email"] == null) {
             val emailResponseDto = githubClient.getUserEmail("Bearer $accessToken").first { it.primary }
             attributes["email"] = emailResponseDto.email

--- a/src/main/kotlin/com/csbroker/apiserver/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/CustomOAuth2UserService.kt
@@ -4,6 +4,7 @@ import com.csbroker.apiserver.common.auth.OAuth2UserInfo
 import com.csbroker.apiserver.common.auth.OAuth2UserInfoFactory
 import com.csbroker.apiserver.common.auth.ProviderType
 import com.csbroker.apiserver.common.auth.UserPrincipal
+import com.csbroker.apiserver.common.util.GithubClient
 import com.csbroker.apiserver.model.User
 import com.csbroker.apiserver.repository.UserRepository
 import org.springframework.security.authentication.InternalAuthenticationServiceException
@@ -16,7 +17,8 @@ import java.util.Locale
 
 @Service
 class CustomOAuth2UserService(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val githubClient: GithubClient
 ) : DefaultOAuth2UserService() {
     override fun loadUser(userRequest: OAuth2UserRequest?): OAuth2User {
         val user = super.loadUser(userRequest)
@@ -34,8 +36,20 @@ class CustomOAuth2UserService(
     private fun process(userRequest: OAuth2UserRequest, user: OAuth2User): OAuth2User {
         val providerType =
             ProviderType.valueOf(userRequest.clientRegistration.registrationId.uppercase(Locale.getDefault()))
-        val userInfo = OAuth2UserInfoFactory.getOauth2UserInfo(providerType, user.attributes)
-        var savedUser = userRepository.findByEmail(userInfo.getEmail())
+
+        val accessToken = userRequest.accessToken.tokenValue
+
+        val attributes = user.attributes.toMutableMap()
+
+        println(attributes)
+
+        if (providerType == ProviderType.GITHUB && attributes["email"] == null) {
+            val emailResponseDto = githubClient.getUserEmail("Bearer $accessToken").first { it.primary }
+            attributes["email"] = emailResponseDto.email
+        }
+
+        val userInfo = OAuth2UserInfoFactory.getOauth2UserInfo(providerType, attributes)
+        var savedUser = this.userRepository.findUserByProviderId(userInfo.getId())
 
         if (savedUser != null) {
             if (providerType != savedUser.providerType) {
@@ -47,7 +61,7 @@ class CustomOAuth2UserService(
             savedUser = this.createUser(userInfo, providerType)
         }
 
-        return UserPrincipal.create(savedUser, user.attributes)
+        return UserPrincipal.create(savedUser, attributes)
     }
 
     private fun createUser(userInfo: OAuth2UserInfo, providerType: ProviderType): User {
@@ -55,7 +69,8 @@ class CustomOAuth2UserService(
             email = userInfo.getEmail(),
             username = userInfo.getName(),
             providerType = providerType,
-            profileImageUrl = userInfo.getImageUrl()
+            profileImageUrl = userInfo.getImageUrl(),
+            providerId = userInfo.getId()
         )
 
         return userRepository.saveAndFlush(user)

--- a/src/test/kotlin/com/csbroker/apiserver/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/csbroker/apiserver/controller/UserControllerTest.kt
@@ -186,7 +186,7 @@ class UserControllerTest {
 
         // when
         val result = mockMvc.perform(
-            MockMvcRequestBuilders.patch(urlTemplate)
+            MockMvcRequestBuilders.put(urlTemplate)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer ${accessToken.token}")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(userUpdateRequestDtoString)


### PR DESCRIPTION
### Issue Number

close: MSTR-177

### 작업 내역

- [x] Github email 조회 불가능 문제 해결

### 변경사항

- Github API 호출을 위한, Feign client 추가

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- Github OAuth에서 유저 정보가 private일 때, email을 전달해주지 않는 것을 파악하여 수정하였습니다.
  - OAuth를 통해 Github access token 획득 -> 이를 통한 Github API 호출을 통해, private email 획득.
- 추가로, username도 설정되지 않은 경우 오류가 발생하여 username 대신 로그인에 사용되는 id를 가져오도록 수정했습니다. 
