### PR TITLE
MSTR-206 : 문제 검색 응답에서 타입 추가 및 타입별 조회 API추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -190,33 +190,89 @@ include::{snippets}/auth/getUserInfo/response-fields.adoc[]
 
 === Problem API ( /api/v1/problems )
 
-==== 문제 단건 조회
+==== 서술형 문제 단건 조회
 
 
 .description
 [source]
 ----
-문제 단건 조회를 위한 API입니다.
+서술형 문제 단건 조회를 위한 API입니다.
 
 HTTP Method : GET
-End-Point   : /api/v1/problems/{problem_id:Long}
+End-Point   : /api/v1/problems/long/{problem_id:Long}
 ----
 
 .Sample Request
-include::{snippets}/problems/inquire/http-request.adoc[]
+include::{snippets}/problems/long/inquire/http-request.adoc[]
 
 .Sample Response
-include::{snippets}/problems/inquire/http-response.adoc[]
+include::{snippets}/problems/long/inquire/http-response.adoc[]
 
 .Path parameters
-include::{snippets}/problems/inquire/path-parameters.adoc[]
+include::{snippets}/problems/long/inquire/path-parameters.adoc[]
 
-문제 단건 조회를 위한 path parameter의 설명입니다.
+서술형 문제 단건 조회를 위한 path parameter의 설명입니다.
 
 
 .Response Body
-include::{snippets}/problems/inquire/response-body.adoc[]
-include::{snippets}/problems/inquire/response-fields.adoc[]
+include::{snippets}/problems/long/inquire/response-body.adoc[]
+include::{snippets}/problems/long/inquire/response-fields.adoc[]
+
+==== 단답형 문제 단건 조회
+
+
+.description
+[source]
+----
+단답형 문제 단건 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v1/problems/short/{problem_id:Long}
+----
+
+.Sample Request
+include::{snippets}/problems/short/inquire/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/problems/short/inquire/http-response.adoc[]
+
+.Path parameters
+include::{snippets}/problems/short/inquire/path-parameters.adoc[]
+
+객관식 문제 단건 조회를 위한 path parameter의 설명입니다.
+
+
+.Response Body
+include::{snippets}/problems/short/inquire/response-body.adoc[]
+include::{snippets}/problems/short/inquire/response-fields.adoc[]
+
+==== 객관식 문제 단건 조회
+
+
+.description
+[source]
+----
+객관식 문제 단건 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v1/problems/multiple/{problem_id:Long}
+----
+
+.Sample Request
+include::{snippets}/problems/multiple/inquire/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/problems/multiple/inquire/http-response.adoc[]
+
+.Path parameters
+include::{snippets}/problems/multiple/inquire/path-parameters.adoc[]
+
+객관식 문제 단건 조회를 위한 path parameter의 설명입니다.
+
+
+.Response Body
+include::{snippets}/problems/multiple/inquire/response-body.adoc[]
+include::{snippets}/problems/multiple/inquire/response-fields.adoc[]
 
 ==== 문제 검색
 

--- a/src/main/kotlin/com/csbroker/apiserver/controller/ProblemController.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/controller/ProblemController.kt
@@ -1,12 +1,13 @@
 package com.csbroker.apiserver.controller
 
 import com.csbroker.apiserver.common.enums.ErrorCode
-import com.csbroker.apiserver.common.exception.EntityNotFoundException
 import com.csbroker.apiserver.common.exception.UnAuthorizedException
 import com.csbroker.apiserver.dto.ApiResponse
-import com.csbroker.apiserver.dto.problem.ProblemDetailResponseDto
+import com.csbroker.apiserver.dto.problem.LongProblemDetailResponseDto
+import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemSearchDto
+import com.csbroker.apiserver.dto.problem.ShortProblemDetailResponseDto
 import com.csbroker.apiserver.service.ProblemService
 import org.springframework.data.domain.Pageable
 import org.springframework.security.core.context.SecurityContextHolder
@@ -48,11 +49,24 @@ class ProblemController(
         return ApiResponse.success(foundProblems)
     }
 
-    @GetMapping("/{id}")
-    fun getProblemById(@PathVariable("id") id: Long): ApiResponse<ProblemDetailResponseDto> {
-        val findProblem = this.problemService.findProblemById(id)
-            ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
+    @GetMapping("/long/{id}")
+    fun getLongProblemById(@PathVariable("id") id: Long): ApiResponse<LongProblemDetailResponseDto> {
+        val findProblemDetail = this.problemService.findLongProblemDetailById(id)
 
-        return ApiResponse.success(findProblem)
+        return ApiResponse.success(findProblemDetail)
+    }
+
+    @GetMapping("/multiple/{id}")
+    fun getMultipleProblemById(@PathVariable("id") id: Long): ApiResponse<MultipleChoiceProblemDetailResponseDto> {
+        val findProblemDetail = this.problemService.findMultipleChoiceProblemDetailById(id)
+
+        return ApiResponse.success(findProblemDetail)
+    }
+
+    @GetMapping("/short/{id}")
+    fun getShortProblemById(@PathVariable("id") id: Long): ApiResponse<ShortProblemDetailResponseDto> {
+        val findProblemDetail = this.problemService.findShortProblemDetailById(id)
+
+        return ApiResponse.success(findProblemDetail)
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/ChoiceResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/ChoiceResponseDto.kt
@@ -1,0 +1,6 @@
+package com.csbroker.apiserver.dto.problem
+
+data class ChoiceResponseDto(
+    val id: Long,
+    val content: String
+)

--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/LongProblemDetailResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/LongProblemDetailResponseDto.kt
@@ -1,6 +1,6 @@
 package com.csbroker.apiserver.dto.problem
 
-data class ProblemDetailResponseDto(
+data class LongProblemDetailResponseDto(
     val id: Long,
     val title: String,
     val tags: List<String>,

--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/MultipleChoiceProblemDetailResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/MultipleChoiceProblemDetailResponseDto.kt
@@ -1,0 +1,13 @@
+package com.csbroker.apiserver.dto.problem
+
+data class MultipleChoiceProblemDetailResponseDto(
+    val id: Long,
+    val title: String,
+    val tags: List<String>,
+    val description: String,
+    val avgScore: Double?,
+    val topScore: Double?,
+    val bottomScore: Double?,
+    val totalSolved: Int,
+    val choices: List<ChoiceResponseDto>
+)

--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/ShortProblemDetailResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/ShortProblemDetailResponseDto.kt
@@ -1,10 +1,13 @@
 package com.csbroker.apiserver.dto.problem
 
-data class ProblemResponseDto(
+data class ShortProblemDetailResponseDto(
     val id: Long,
     val title: String,
     val tags: List<String>,
+    val description: String,
     val avgScore: Double?,
+    val topScore: Double?,
+    val bottomScore: Double?,
     val totalSolved: Int,
-    val type: String
+    val answerLength: Int
 )

--- a/src/main/kotlin/com/csbroker/apiserver/model/Choice.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/Choice.kt
@@ -1,5 +1,6 @@
 package com.csbroker.apiserver.model
 
+import com.csbroker.apiserver.dto.problem.ChoiceResponseDto
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -27,4 +28,11 @@ class Choice(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     var multipleChoiceProblem: MultipleChoiceProblem
-)
+) {
+    fun toChoiceResponseDto(): ChoiceResponseDto {
+        return ChoiceResponseDto(
+            this.id!!,
+            this.content
+        )
+    }
+}

--- a/src/main/kotlin/com/csbroker/apiserver/model/LongProblem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/LongProblem.kt
@@ -1,5 +1,6 @@
 package com.csbroker.apiserver.model
 
+import com.csbroker.apiserver.dto.problem.LongProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemUpsertRequestDto
@@ -70,6 +71,32 @@ class LongProblem(
             if (promptScores.isEmpty()) null else promptScores.average(),
             this.userAnswers.size,
             this.isActive
+        )
+    }
+    fun toDetailResponseDto(): LongProblemDetailResponseDto {
+        val tags = this.problemTags.map {
+            it.tag
+        }.map {
+            it.name
+        }
+
+        val scoreList = this.gradingHistory.map {
+            it.score
+        }.toList().sorted()
+
+        val totalSolved = this.gradingHistory.map {
+            it.user.username
+        }.distinct().size
+
+        return LongProblemDetailResponseDto(
+            this.id!!,
+            this.title,
+            tags,
+            this.description,
+            if (scoreList.isEmpty()) null else scoreList.average(),
+            if (scoreList.isEmpty()) null else scoreList.first(),
+            if (scoreList.isEmpty()) null else scoreList.last(),
+            totalSolved
         )
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/model/MultipleChoiceProblem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/MultipleChoiceProblem.kt
@@ -1,5 +1,6 @@
 package com.csbroker.apiserver.model
 
+import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemUpsertRequestDto
 import com.csbroker.apiserver.dto.problem.MultipleProblemResponseDto
@@ -81,6 +82,34 @@ class MultipleChoiceProblem(
             if (answerCnt == 0) null else correctAnswerCnt / answerCnt.toDouble(),
             answerCnt,
             this.isActive
+        )
+    }
+
+    fun toDetailResponseDto(): MultipleChoiceProblemDetailResponseDto {
+        val tags = this.problemTags.map {
+            it.tag
+        }.map {
+            it.name
+        }
+
+        val scoreList = this.gradingHistory.map {
+            it.score
+        }.toList().sorted()
+
+        val totalSolved = this.gradingHistory.map {
+            it.user.username
+        }.distinct().size
+
+        return MultipleChoiceProblemDetailResponseDto(
+            this.id!!,
+            this.title,
+            tags,
+            this.description,
+            if (scoreList.isEmpty()) null else scoreList.average(),
+            if (scoreList.isEmpty()) null else scoreList.first(),
+            if (scoreList.isEmpty()) null else scoreList.last(),
+            totalSolved,
+            this.choicesList.map { it.toChoiceResponseDto() }
         )
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/model/Problem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/Problem.kt
@@ -1,6 +1,5 @@
 package com.csbroker.apiserver.model
 
-import com.csbroker.apiserver.dto.problem.ProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemResponseDto
 import javax.persistence.CascadeType
 import javax.persistence.Column
@@ -78,34 +77,8 @@ abstract class Problem(
             this.title,
             tags,
             avgScore,
-            totalSolved
-        )
-    }
-
-    fun toProblemDetailResponseDto(): ProblemDetailResponseDto {
-        val tags = this.problemTags.map {
-            it.tag
-        }.map {
-            it.name
-        }
-
-        val scoreList = this.gradingHistory.map {
-            it.score
-        }.toList().sorted()
-
-        val totalSolved = this.gradingHistory.map {
-            it.user.username
-        }.distinct().size
-
-        return ProblemDetailResponseDto(
-            this.id!!,
-            this.title,
-            tags,
-            this.description,
-            if (scoreList.isEmpty()) null else scoreList.average(),
-            if (scoreList.isEmpty()) null else scoreList.first(),
-            if (scoreList.isEmpty()) null else scoreList.last(),
-            totalSolved
+            totalSolved,
+            this.dtype
         )
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
@@ -1,5 +1,6 @@
 package com.csbroker.apiserver.model
 
+import com.csbroker.apiserver.dto.problem.ShortProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemUpsertRequestDto
@@ -57,6 +58,34 @@ class ShortProblem(
             if (answerCnt == 0) null else correctAnswerCnt / answerCnt.toDouble(),
             answerCnt,
             this.isActive
+        )
+    }
+
+    fun toDetailResponseDto(): ShortProblemDetailResponseDto {
+        val tags = this.problemTags.map {
+            it.tag
+        }.map {
+            it.name
+        }
+
+        val scoreList = this.gradingHistory.map {
+            it.score
+        }.toList().sorted()
+
+        val totalSolved = this.gradingHistory.map {
+            it.user.username
+        }.distinct().size
+
+        return ShortProblemDetailResponseDto(
+            this.id!!,
+            this.title,
+            tags,
+            this.description,
+            if (scoreList.isEmpty()) null else scoreList.average(),
+            if (scoreList.isEmpty()) null else scoreList.first(),
+            if (scoreList.isEmpty()) null else scoreList.last(),
+            totalSolved,
+            this.answer.length
         )
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/service/ProblemService.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/ProblemService.kt
@@ -1,14 +1,16 @@
 package com.csbroker.apiserver.service
 
+import com.csbroker.apiserver.dto.problem.LongProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemUpsertRequestDto
+import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemUpsertRequestDto
 import com.csbroker.apiserver.dto.problem.MultipleProblemResponseDto
-import com.csbroker.apiserver.dto.problem.ProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemSearchDto
+import com.csbroker.apiserver.dto.problem.ShortProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemUpsertRequestDto
@@ -37,7 +39,9 @@ interface ProblemService {
         pageable: Pageable
     ): MultipleChoiceProblemSearchResponseDto
 
-    fun findProblemById(id: Long): ProblemDetailResponseDto?
+    fun findLongProblemDetailById(id: Long): LongProblemDetailResponseDto
+    fun findShortProblemDetailById(id: Long): ShortProblemDetailResponseDto
+    fun findMultipleChoiceProblemDetailById(id: Long): MultipleChoiceProblemDetailResponseDto
     fun findLongProblemById(id: Long): LongProblemResponseDto
     fun findShortProblemById(id: Long): ShortProblemResponseDto
     fun findMultipleProblemById(id: Long): MultipleProblemResponseDto

--- a/src/main/kotlin/com/csbroker/apiserver/service/ProblemServiceImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/ProblemServiceImpl.kt
@@ -3,15 +3,17 @@ package com.csbroker.apiserver.service
 import com.csbroker.apiserver.common.enums.ErrorCode
 import com.csbroker.apiserver.common.exception.ConditionConflictException
 import com.csbroker.apiserver.common.exception.EntityNotFoundException
+import com.csbroker.apiserver.dto.problem.LongProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.LongProblemUpsertRequestDto
+import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.MultipleChoiceProblemUpsertRequestDto
 import com.csbroker.apiserver.dto.problem.MultipleProblemResponseDto
-import com.csbroker.apiserver.dto.problem.ProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ProblemSearchDto
+import com.csbroker.apiserver.dto.problem.ShortProblemDetailResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemSearchResponseDto
 import com.csbroker.apiserver.dto.problem.ShortProblemUpsertRequestDto
@@ -98,8 +100,19 @@ class ProblemServiceImpl(
         )
     }
 
-    override fun findProblemById(id: Long): ProblemDetailResponseDto? {
-        return problemRepository.findByIdOrNull(id)?.toProblemDetailResponseDto()
+    override fun findLongProblemDetailById(id: Long): LongProblemDetailResponseDto {
+        return longProblemRepository.findByIdOrNull(id)?.toDetailResponseDto()
+            ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
+    }
+
+    override fun findShortProblemDetailById(id: Long): ShortProblemDetailResponseDto {
+        return shortProblemRepository.findByIdOrNull(id)?.toDetailResponseDto()
+            ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
+    }
+
+    override fun findMultipleChoiceProblemDetailById(id: Long): MultipleChoiceProblemDetailResponseDto {
+        return multipleChoiceProblemRepository.findByIdOrNull(id)?.toDetailResponseDto()
+            ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
     }
 
     override fun findLongProblemById(id: Long): LongProblemResponseDto {

--- a/src/test/kotlin/com/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
+++ b/src/test/kotlin/com/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
@@ -379,7 +379,7 @@ class ProblemApiControllerTest {
                         fieldWithPath("data.[].totalSolved").type(JsonFieldType.NUMBER)
                             .description("문제를 푼 사람 수"),
                         fieldWithPath("data.[].type").type(JsonFieldType.STRING)
-                            .description("문제의 타입 ( short, multiple, choice )"),
+                            .description("문제의 타입 ( short, multiple, choice )")
                     )
                 )
             )


### PR DESCRIPTION
### Issue Number

close: MSTR-206

### 작업 내역

- [x] 문제 검색 응답에서 타입 추가 및 타입별 조회 API추가
- [x] 테스트 코드 작성 및 docs 업데이트

### 변경사항

N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [x] 문서 업데이트

### PR 특이 사항

- long, multiple, short 문제의 타입을 검색 결과에 포함하게 되었습니다.
- 각 타입별 조회 API가 추가 되었습니다.
  - 이에 따라, 단일 조회 API가 삭제되었습니다.
- 테스트 코드 및 docs가 수정되었습니다.

