### PR TITLE
MSTR-233 : Add answer language field

### DIFF
--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/shortproblem/ShortProblemDetailResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/shortproblem/ShortProblemDetailResponseDto.kt
@@ -8,5 +8,6 @@ data class ShortProblemDetailResponseDto(
     val correctCnt: Int,
     val wrongCnt: Int,
     val totalSolved: Int,
-    val answerLength: Int
+    val answerLength: Int,
+    val isEnglish: Boolean
 )

--- a/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
@@ -90,7 +90,7 @@ class ShortProblem(
     }
 
     private fun isEnglish(): Boolean {
-        for (c in this.answer) {
+        for (c in this.answer.replace("\\s".toRegex(), "")) {
             if (c !in 'A'..'Z' && c !in 'a'..'z' && c !in '0'..'9') {
                 return false
             }

--- a/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/ShortProblem.kt
@@ -84,7 +84,17 @@ class ShortProblem(
             scoreList.count { it == this.score },
             scoreList.count { it != this.score },
             totalSolved,
-            this.answer.length
+            this.answer.length,
+            this.isEnglish()
         )
+    }
+
+    private fun isEnglish(): Boolean {
+        for (c in this.answer) {
+            if (c !in 'A'..'Z' && c !in 'a'..'z' && c !in '0'..'9') {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/src/test/kotlin/com/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
+++ b/src/test/kotlin/com/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
@@ -285,7 +285,9 @@ class ProblemApiControllerTest {
                         fieldWithPath("data.totalSolved").type(JsonFieldType.NUMBER)
                             .description("문제를 푼 사람 수"),
                         fieldWithPath("data.answerLength").type(JsonFieldType.NUMBER)
-                            .description("정답 글자수 ( 힌트 )")
+                            .description("정답 글자수 ( 힌트 )"),
+                        fieldWithPath("data.isEnglish").type(JsonFieldType.BOOLEAN)
+                            .description("정답 언어 ( 영어면 true, 한국어면 false )")
                     )
                 )
             )


### PR DESCRIPTION
### Issue Number

close: MSTR-233

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 답안이 영어인지 한글인지 구분하는 응답 필드 추가
- [x] 필드 추가에 따른 테스트 코드 변경

### 변경사항

N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 간단하게 isEnglish 필드를 추가했습니다. 영어 + 숫자 조합이면 true, 한글 + 숫자 조합이면 false 입니다.
  - 만약에, 숫자만 답이라면 isEnglish가 true로 갈텐데.. 이 부분은 isNumeric 같은 필드를 추가하는게 조금 애매한 것 같아서 일단 보류입니다.

