### PR TITLE
MSTR-244 : 유저 Soft delete api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -494,6 +494,34 @@ include::{snippets}/users/update/request-fields.adoc[]
 include::{snippets}/users/update/response-body.adoc[]
 include::{snippets}/users/update/response-fields.adoc[]
 
+==== 유저 삭제
+
+.description
+[source]
+----
+유저 삭제를 위한 API입니다.
+
+HTTP Method : DELETE
+End-Point   : /api/v1/users/{userID: UUID}
+----
+
+.Sample Request
+include::{snippets}/users/deleteOne/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/users/deleteOne/http-response.adoc[]
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+
+이 Access Token은 회원 인증을 위해 필수적으로 포함되어야 합니다.
+
+include::{snippets}/users/deleteOne/request-headers.adoc[]
+
+.Response Body
+include::{snippets}/users/deleteOne/response-body.adoc[]
+include::{snippets}/users/deleteOne/response-fields.adoc[]
+
 == Back-Office APIs
 
 백오피스에서 사용되는 API입니다.

--- a/src/main/kotlin/com/csbroker/apiserver/controller/UserController.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/controller/UserController.kt
@@ -3,11 +3,13 @@ package com.csbroker.apiserver.controller
 import com.csbroker.apiserver.auth.LoginUser
 import com.csbroker.apiserver.common.exception.EntityNotFoundException
 import com.csbroker.apiserver.dto.common.ApiResponse
+import com.csbroker.apiserver.dto.common.DeleteResponseDto
 import com.csbroker.apiserver.dto.user.UserResponseDto
 import com.csbroker.apiserver.dto.user.UserUpdateRequestDto
 import com.csbroker.apiserver.service.UserService
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.userdetails.User
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -58,5 +60,14 @@ class UserController(
         val user = this.userService.modifyUser(id, userUpdateRequestDto)
 
         return ApiResponse.success(user.toUserResponseDto())
+    }
+
+    @DeleteMapping("/{id}")
+    fun deleteUser(
+        @LoginUser loginUser: User,
+        @PathVariable("id") id: UUID
+    ): ApiResponse<DeleteResponseDto> {
+        val result = this.userService.deleteUser(loginUser.username, id)
+        return ApiResponse.success(DeleteResponseDto(id, result))
     }
 }

--- a/src/main/kotlin/com/csbroker/apiserver/dto/common/DeleteResponseDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/common/DeleteResponseDto.kt
@@ -1,0 +1,6 @@
+package com.csbroker.apiserver.dto.common
+
+data class DeleteResponseDto(
+    val id: Any,
+    val result: Boolean = true
+)

--- a/src/main/kotlin/com/csbroker/apiserver/model/User.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/User.kt
@@ -63,6 +63,9 @@ class User(
     @Column(name = "linkedin_url")
     var linkedinUrl: String? = null,
 
+    @Column(name = "is_deleted", columnDefinition = "boolean default 0")
+    var isDeleted: Boolean = false,
+
     @OneToMany(mappedBy = "creator", fetch = FetchType.LAZY)
     val problems: MutableList<Problem> = mutableListOf(),
 
@@ -70,7 +73,7 @@ class User(
     val assignedAnswers: MutableList<UserAnswer> = mutableListOf(),
 
     @OneToMany(mappedBy = "validatingUser", fetch = FetchType.LAZY)
-    val assignedToValidateAnswers: MutableList<UserAnswer> = mutableListOf(),
+    val assignedToValidateAnswers: MutableList<UserAnswer> = mutableListOf()
 ) : BaseEntity() {
     fun updateInfo(userUpdateRequestDto: UserUpdateRequestDto) {
         this.profileImageUrl = userUpdateRequestDto.profileImageUrl ?: this.profileImageUrl

--- a/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
@@ -3,11 +3,20 @@ package com.csbroker.apiserver.repository
 import com.csbroker.apiserver.common.enums.Role
 import com.csbroker.apiserver.model.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface UserRepository : JpaRepository<User, UUID> {
-    fun findByEmail(email: String): User?
+    @Query("select u from User u where u.email = :email and u.isDeleted = FALSE")
+    fun findByEmail(@Param("email") email: String): User?
+
+    @Query("select u from User u where u.id = :id and u.isDeleted = FALSE")
+    fun findByIdOrNull(@Param("id") id: UUID): User?
+
     fun findByEmailOrUsername(email: String, username: String): User?
+
     fun findUsersByRole(role: Role): List<User>
+
     fun findUserByProviderId(providerId: String): User?
 }

--- a/src/main/kotlin/com/csbroker/apiserver/service/UserService.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/UserService.kt
@@ -14,4 +14,6 @@ interface UserService {
     fun findUsers(): List<User>
 
     fun findAdminUsers(): List<User>
+
+    fun deleteUser(email: String, id: UUID): Boolean
 }

--- a/src/main/kotlin/com/csbroker/apiserver/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/UserServiceImpl.kt
@@ -1,7 +1,9 @@
 package com.csbroker.apiserver.service
 
+import com.csbroker.apiserver.common.enums.ErrorCode
 import com.csbroker.apiserver.common.enums.Role
 import com.csbroker.apiserver.common.exception.EntityNotFoundException
+import com.csbroker.apiserver.common.exception.UnAuthorizedException
 import com.csbroker.apiserver.dto.user.UserUpdateRequestDto
 import com.csbroker.apiserver.model.User
 import com.csbroker.apiserver.repository.UserRepository
@@ -45,5 +47,18 @@ class UserServiceImpl(
 
     override fun findAdminUsers(): List<User> {
         return this.userRepository.findUsersByRole(Role.ROLE_ADMIN)
+    }
+
+    override fun deleteUser(email: String, id: UUID): Boolean {
+        val findUserById = this.findUserById(id)
+            ?: throw EntityNotFoundException("${id}를 가진 유저를 찾을 수 없습니다.")
+
+        if (findUserById.email != email) {
+            throw UnAuthorizedException(ErrorCode.UNAUTHORIZED, "해당 유저를 삭제할 권한이 없습니다.")
+        }
+
+        findUserById.isDeleted = true
+
+        return true
     }
 }

--- a/src/test/kotlin/com/csbroker/apiserver/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/csbroker/apiserver/unit/service/UserServiceTest.kt
@@ -70,13 +70,13 @@ class UserServiceTest {
     @Test
     fun `유저 정보 ID 조회 성공 테스트`() {
         // given
-        every { userRepository.findByIdOrNull(user.id) } returns user
+        every { userRepository.findByIdOrNull(user.id!!) } returns user
 
         // when
         val userInfo = userService.findUserById(user.id!!)
 
         // then
-        verify(exactly = 1) { userRepository.findByIdOrNull(user.id) }
+        verify(exactly = 1) { userRepository.findByIdOrNull(user.id!!) }
         Assertions.assertThat(userInfo).isNotNull
         Assertions.assertThat(user.id).isEqualTo(userInfo!!.id)
     }
@@ -143,7 +143,7 @@ class UserServiceTest {
     @Test
     fun `유저 수정 성공 without password 테스트`() {
         // given
-        val id = user.id
+        val id = user.id!!
         val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", null)
         every { userRepository.findByIdOrNull(id) } returns user
 
@@ -163,7 +163,7 @@ class UserServiceTest {
     @Test
     fun `유저 수정 성공 with password 테스트`() {
         // given
-        val id = user.id
+        val id = user.id!!
         val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", "test123!")
         every { userRepository.findByIdOrNull(id) } returns user
         every { passwordEncoder.encode("test123!") } returns "some-encrypted-password"


### PR DESCRIPTION
### Issue Number

close: MSTR-244

### 작업 내역

- [x] 유저 Soft delete api 추가
- [x] 유저 조회시 query에 isDeleted = false 인것만 가져오도록 수정
- [x] 유저 삭제 API 문서화 

### 변경사항
N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [X] 문서 업데이트

### PR 특징

- API 추가에 따른 테스트 및 필드 수정이 있었습니다.
- 유저 조회 쿼리를 수정해서, 비즈니스 로직 수정없이 권한 체크를했습니다. ( 넘 행복해 )