### PR TITLE
MSTR-264 : 메인페이지 통계 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -188,6 +188,30 @@ include::{snippets}/auth/getUserInfo/request-headers.adoc[]
 include::{snippets}/auth/getUserInfo/response-body.adoc[]
 include::{snippets}/auth/getUserInfo/response-fields.adoc[]
 
+=== Common API ( /api/v1 )
+
+==== 메인페이지 통계 API
+
+.description
+[source]
+----
+메인페이지 통계 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v1/stats
+----
+
+.Sample Request
+include::{snippets}/common/stats/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/common/stats/http-response.adoc[]
+
+.Response Body
+include::{snippets}/common/stats/response-body.adoc[]
+include::{snippets}/common/stats/response-fields.adoc[]
+
+
 === Problem API ( /api/v1/problems )
 
 ==== 서술형 문제 단건 조회

--- a/src/main/kotlin/com/csbroker/apiserver/controller/CommonController.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/controller/CommonController.kt
@@ -1,0 +1,19 @@
+package com.csbroker.apiserver.controller
+
+import com.csbroker.apiserver.dto.StatsDto
+import com.csbroker.apiserver.dto.common.ApiResponse
+import com.csbroker.apiserver.service.CommonService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class CommonController(
+    private val commonService: CommonService
+) {
+    @GetMapping("/stats")
+    fun getStats(): ApiResponse<StatsDto> {
+        return ApiResponse.success(commonService.getStats())
+    }
+}

--- a/src/main/kotlin/com/csbroker/apiserver/dto/StatsDto.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/StatsDto.kt
@@ -1,0 +1,7 @@
+package com.csbroker.apiserver.dto
+
+data class StatsDto(
+    val problemCnt: Long,
+    val gradableProblemCnt: Long,
+    val userCnt: Long
+)

--- a/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepository.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepository.kt
@@ -2,7 +2,11 @@ package com.csbroker.apiserver.repository
 
 import com.csbroker.apiserver.model.Problem
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface ProblemRepository : JpaRepository<Problem, Long>, ProblemRepositoryCustom {
     fun deleteProblemsByIdIn(ids: List<Long>)
+
+    @Query("select count(p) from Problem p where p.isGradable = TRUE")
+    fun countGradableProblem(): Long
 }

--- a/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepository.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepository.kt
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query
 interface ProblemRepository : JpaRepository<Problem, Long>, ProblemRepositoryCustom {
     fun deleteProblemsByIdIn(ids: List<Long>)
 
-    @Query("select count(p) from Problem p where p.isGradable = TRUE")
+    @Query("select count(p) from Problem p where p.isGradable = TRUE and p.isActive = TRUE")
     fun countGradableProblem(): Long
 }

--- a/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/UserRepository.kt
@@ -19,4 +19,7 @@ interface UserRepository : JpaRepository<User, UUID> {
     fun findUsersByRole(role: Role): List<User>
 
     fun findUserByProviderId(providerId: String): User?
+
+    @Query("select count(u) from User u where u.isDeleted = FALSE")
+    fun countUser(): Long
 }

--- a/src/main/kotlin/com/csbroker/apiserver/service/CommonService.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/CommonService.kt
@@ -1,0 +1,9 @@
+package com.csbroker.apiserver.service
+
+import com.csbroker.apiserver.dto.StatsDto
+import com.csbroker.apiserver.dto.problem.ProblemResponseDto
+
+interface CommonService {
+    fun getStats(): StatsDto
+    fun getTodayProblems(): List<ProblemResponseDto>
+}

--- a/src/main/kotlin/com/csbroker/apiserver/service/CommonServiceImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/service/CommonServiceImpl.kt
@@ -1,0 +1,28 @@
+package com.csbroker.apiserver.service
+
+import com.csbroker.apiserver.dto.StatsDto
+import com.csbroker.apiserver.dto.problem.ProblemResponseDto
+import com.csbroker.apiserver.repository.ProblemRepository
+import com.csbroker.apiserver.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CommonServiceImpl(
+    private val problemRepository: ProblemRepository,
+    private val userRepository: UserRepository
+) : CommonService {
+
+    override fun getStats(): StatsDto {
+        val problemCnt = problemRepository.count()
+        val gradableProblemCnt = problemRepository.countGradableProblem()
+        val userCnt = userRepository.countUser()
+
+        return StatsDto(problemCnt, gradableProblemCnt, userCnt)
+    }
+
+    override fun getTodayProblems(): List<ProblemResponseDto> {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/com/csbroker/apiserver/e2e/CommonControllerTest.kt
+++ b/src/test/kotlin/com/csbroker/apiserver/e2e/CommonControllerTest.kt
@@ -1,0 +1,62 @@
+package com.csbroker.apiserver.e2e
+
+import org.hamcrest.CoreMatchers
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CommonControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `Get stats`() {
+        // given
+        val statsEndPoint = "/api/v1/stats"
+
+        // when
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(statsEndPoint)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "common/stats",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.problemCnt")
+                            .type(JsonFieldType.NUMBER).description("문제 수"),
+                        PayloadDocumentation.fieldWithPath("data.gradableProblemCnt")
+                            .type(JsonFieldType.NUMBER).description("채점 가능한 문제 수"),
+                        PayloadDocumentation.fieldWithPath("data.userCnt")
+                            .type(JsonFieldType.NUMBER).description("회원 수")
+                    )
+                )
+            )
+    }
+}


### PR DESCRIPTION
### Issue Number

close: MSTR-264

### 작업 내역

![스크린샷 2022-09-14 오후 1 33 22](https://user-images.githubusercontent.com/36851531/190060268-23dba090-c992-4060-990b-72e5dca5803d.png)

위 컴포넌트에 사용되는 통계 API를 구현했습니다.

- [x] 통계 API 구현
- [x] 테스트 작성
- [x] 문서 업데이트 

### 변경사항

N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [x] 문서 업데이트

### PR 특이 사항

- 간단하게 사용할 수 있는 API라 빠르게 구현하고, 테스트 작성했습니다.
- `getTodayProblems` 는 미래에 구현을 위해서, 일단 interface에 함수 원형만 놓고 TODO를 넣어놨습니다~
