### PR TITLE
HOTFIX : 비밀번호를 로깅하지 않도록 정규표현식 적용

### DIFF
--- a/src/main/kotlin/com/csbroker/apiserver/common/filter/LoggingFilter.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/common/filter/LoggingFilter.kt
@@ -69,7 +69,12 @@ class LoggingFilter : OncePerRequestFilter() {
         if (visible) {
             val content: ByteArray = StreamUtils.copyToByteArray(inputStream)
             if (content.isNotEmpty()) {
-                val contentString = String(content)
+                var contentString = String(content)
+
+                if (contentString.contains("password")) {
+                    contentString = contentString.replace("\"password\":\".*\"".toRegex(), "\"password\":\"*****\"")
+                }
+
                 log.info("{} Payload: {}", prefix, contentString)
             }
         } else {


### PR DESCRIPTION
### Issue Number

close: N/A

<img width="317" alt="스크린샷 2022-09-19 오전 3 54 44" src="https://user-images.githubusercontent.com/36851531/190951388-f5642d95-cfb0-4ded-b88d-1518246d8c27.png">

### 작업 내역

- [x] 비밀번호를 로깅하지 않도록 정규표현식 적용

### 변경사항

- N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

-  현재 로깅시 req body를 로깅하고 있는데, 이게 로그인시에 이메일-비밀번호도 함께 로깅될 것 같아 정규표현식을 통해 제거했습니다.
- regex는 다음과 같아요.
  - ![스크린샷 2022-09-19 오후 3 17 52](https://user-images.githubusercontent.com/36851531/190959330-10dda86f-641e-41c5-8a8c-4121b06be113.png)
 
