### PR TITLE
MSTR-283 : Fix problem search api bug

### DIFF
--- a/src/main/kotlin/com/csbroker/apiserver/dto/problem/GradingHistoryStats.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/dto/problem/GradingHistoryStats.kt
@@ -1,0 +1,27 @@
+package com.csbroker.apiserver.dto.problem
+
+import com.csbroker.apiserver.model.GradingHistory
+
+data class GradingHistoryStats(
+    val avgScore: Double?,
+    val totalSolved: Int
+) {
+    companion object {
+        fun toGradingHistoryStats(gradingHistories: List<GradingHistory>): GradingHistoryStats {
+            return GradingHistoryStats(
+                gradingHistories.map {
+                    it.score
+                }.average().let {
+                    if (it.isNaN()) {
+                        null
+                    } else {
+                        it
+                    }
+                },
+                gradingHistories.map {
+                    it.user.username
+                }.distinct().size
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/csbroker/apiserver/model/Problem.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/model/Problem.kt
@@ -1,5 +1,6 @@
 package com.csbroker.apiserver.model
 
+import com.csbroker.apiserver.dto.problem.GradingHistoryStats
 import com.csbroker.apiserver.dto.problem.ProblemResponseDto
 import javax.persistence.CascadeType
 import javax.persistence.Column
@@ -54,33 +55,19 @@ abstract class Problem(
     @OneToMany(mappedBy = "problem", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     val gradingHistory: MutableList<GradingHistory> = mutableListOf()
 ) : BaseEntity() {
-    fun toProblemResponseDto(): ProblemResponseDto {
+    fun toProblemResponseDto(gradingHistoryStats: GradingHistoryStats): ProblemResponseDto {
         val tags = this.problemTags.map {
             it.tag
         }.map {
             it.name
         }
 
-        val avgScore = this.gradingHistory.map {
-            it.score
-        }.average().let {
-            if (it.isNaN()) {
-                null
-            } else {
-                it
-            }
-        }
-
-        val totalSolved = this.gradingHistory.map {
-            it.user.username
-        }.distinct().size
-
         return ProblemResponseDto(
             this.id!!,
             this.title,
             tags,
-            avgScore,
-            totalSolved,
+            gradingHistoryStats.avgScore,
+            gradingHistoryStats.totalSolved,
             this.dtype
         )
     }

--- a/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
@@ -36,7 +36,6 @@ class ProblemRepositoryCustomImpl(
                 this.isType(problemSearchDto.type),
                 this.isGradable(problemSearchDto.isGradable)
             )
-            .orderBy(problem.updatedAt.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()

--- a/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
@@ -46,14 +46,7 @@ class ProblemRepositoryCustomImpl(
             .leftJoin(gradingHistory.user, user).fetchJoin()
             .leftJoin(problem.problemTags, problemTag).fetchJoin()
             .leftJoin(problemTag.tag, tag).fetchJoin()
-            .where(
-                this.likeTitle(problemSearchDto.query),
-                this.inTags(problemSearchDto.tags),
-                this.solvedBy(problemSearchDto.solvedBy),
-                this.isType(problemSearchDto.type),
-                this.isGradable(problemSearchDto.isGradable),
-                problem.id.`in`(ids)
-            )
+            .where(problem.id.`in`(ids))
             .fetch()
 
         val gradingHistories = this.queryFactory.selectFrom(gradingHistory)


### PR DESCRIPTION
### Issue Number

close: MSTR-283

### 작업 내역

- [x] 내가 푼 문제 조회시 평균 점수 및 푼 사람 수가 제대로 조회되지 않던 버그 수정
- [x] 메모리에서 페이징을 하던 문제점 개선

### 변경사항

- 의존성 목록 ( N/A )

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 쿼리 수가 늘어났지만, 이전과 달리 메모리에서 페이징을 하지 않고 쿼리를 통해 제대로 된 페이지네이션이 가능해졌습니다.
- 평균 점수 및 푼 사람 수가 제대로 조회되지 않던 버그를 수정했습니다.

