### PR TITLE
MSTR-316 : 랭킹 데이터 응답 속도 개선

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/common/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/RedisCacheConfig.kt
@@ -28,7 +28,7 @@ class RedisCacheConfig {
                     GenericJackson2JsonRedisSerializer()
                 )
             )
-            .entryTtl(Duration.ofMinutes(10L))
+            .entryTtl(Duration.ofMinutes(5L))
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
             .cacheDefaults(redisCacheConfiguration)

--- a/src/main/kotlin/io/csbroker/apiserver/common/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/RedisCacheConfig.kt
@@ -1,0 +1,37 @@
+package io.csbroker.apiserver.common.config
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig {
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .entryTtl(Duration.ofMinutes(10L))
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/dto/StatsDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/StatsDto.kt
@@ -4,4 +4,6 @@ data class StatsDto(
     val problemCnt: Long,
     val gradableProblemCnt: Long,
     val userCnt: Long
-)
+) {
+    constructor() : this(0, 0, 0)
+}

--- a/src/main/kotlin/io/csbroker/apiserver/dto/common/RankListDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/common/RankListDto.kt
@@ -9,10 +9,14 @@ data class RankListDto(
     val numberOfElements: Long,
     val contents: List<RankDetail>
 ) {
+    constructor() : this(0, 0, 0, 0, arrayListOf())
+
     data class RankDetail(
         val id: UUID,
         val username: String,
         val rank: Long,
         val score: Double
-    )
+    ) {
+        constructor() : this(UUID.randomUUID(), "", 0, 0.0)
+    }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/dto/user/UserStatsDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/user/UserStatsDto.kt
@@ -8,9 +8,13 @@ data class UserStatsDto(
     val rank: Long?,
     val score: Double
 ) {
+    constructor() : this(arrayListOf(), arrayListOf(), arrayListOf(), mapOf(), null, 0.0)
+
     data class ProblemStatsDto(
         val id: Long,
         val type: String,
         val title: String
-    )
+    ) {
+        constructor() : this(0, "", "")
+    }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/CommonServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/CommonServiceImpl.kt
@@ -7,6 +7,7 @@ import io.csbroker.apiserver.repository.ProblemRepository
 import io.csbroker.apiserver.repository.TechRepository
 import io.csbroker.apiserver.repository.UserRepository
 import io.csbroker.apiserver.repository.common.RedisRepository
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -31,6 +32,7 @@ class CommonServiceImpl(
         TODO("Not yet implemented")
     }
 
+    @Cacheable(value = ["RankListDto"], key = "#size + '-' + #page")
     override fun getRanks(size: Long, page: Long): RankListDto {
         return redisRepository.getRanks(size, page)
     }

--- a/src/main/kotlin/io/csbroker/apiserver/service/CommonServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/CommonServiceImpl.kt
@@ -20,6 +20,7 @@ class CommonServiceImpl(
     private val redisRepository: RedisRepository
 ) : CommonService {
 
+    @Cacheable(value = ["StatsDto"])
     override fun getStats(): StatsDto {
         val problemCnt = problemRepository.count()
         val gradableProblemCnt = problemRepository.countGradableProblem()

--- a/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
@@ -11,6 +11,7 @@ import io.csbroker.apiserver.model.User
 import io.csbroker.apiserver.repository.GradingHistoryRepository
 import io.csbroker.apiserver.repository.UserRepository
 import io.csbroker.apiserver.repository.common.RedisRepository
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
@@ -56,6 +57,7 @@ class UserServiceImpl(
         return this.userRepository.findUsersByRole(Role.ROLE_ADMIN)
     }
 
+    @Cacheable(value = ["UserStatsDto"], key = "#id")
     override fun getStats(id: UUID): UserStatsDto {
         val findUser = this.userRepository.findByIdOrNull(id)
             ?: throw EntityNotFoundException("${id}를 가진 유저를 찾을 수 없습니다.")


### PR DESCRIPTION
### Issue Number

close: MSTR-316

### 작업 내역

- [x] 랭킹 데이터 응답에 대하여 속도적으로 병목이 가능한 지점에 캐시를 추가하였습니다.
- [x] 추가적으로 공통적으로 많이 조회되거나, 조회 될 데이터에 캐시를 추가했습니다.

### 변경사항

- 의존성 목록 ( N/A )

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 캐시 데이터를 저장하고 불러올 때, GenricJackson2Serializer 는 default constructor ( no argument constructor ) 가 필요한데 기본적으로 data class 는 지원하지 않아 캐시용 데이터로 사용되는 DTO에 default constructor를 추가했습니다.

