### PR TITLE
Hotfix : 유저 응답 삭제 API 구현 및 채점 결과에 내용 채점 기준 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1324,6 +1324,26 @@ include::{snippets}/admin/userAnswer/assign/validate/request-fields.adoc[]
 include::{snippets}/admin/userAnswer/assign/validate/response-body.adoc[]
 include::{snippets}/admin/userAnswer/assign/validate/response-fields.adoc[]
 
+==== 유저 응답 삭제
+
+.description
+[source]
+----
+하나의 유저 응답을 삭제하기 위한 API입니다.
+
+HTTP Method : DELETE
+End-Point   : /api/admin/user-answers/{user_answer_id: Long}
+----
+
+.Sample Request
+include::{snippets}/admin/userAnswer/deleteOne/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/admin/userAnswer/deleteOne/http-response.adoc[]
+
+.Response Body
+include::{snippets}/admin/userAnswer/deleteOne/response-body.adoc[]
+include::{snippets}/admin/userAnswer/deleteOne/response-fields.adoc[]
 
 === User API ( /api/admin/users )
 

--- a/src/main/kotlin/io/csbroker/apiserver/controller/AdminController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/AdminController.kt
@@ -261,6 +261,14 @@ class AdminController(
         )
     }
 
+    @DeleteMapping("/user-answers/{id}")
+    fun deleteUserAnswerById(
+        @PathVariable("id") id: Long
+    ): ApiResponse<Boolean> {
+        this.userAnswerService.removeUserAnswerById(id)
+        return ApiResponse.success(true)
+    }
+
     @PutMapping("/user-answers/assign/{type:label|validate}")
     fun assignUserAnswer(
         @PathVariable("type") type: String,

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/ContentDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/ContentDto.kt
@@ -1,0 +1,7 @@
+package io.csbroker.apiserver.dto.problem.longproblem
+
+class ContentDto(
+    val id: Long,
+    val content: String,
+    val isExist: Boolean = false
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemGradingHistoryDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemGradingHistoryDto.kt
@@ -14,6 +14,7 @@ data class LongProblemGradingHistoryDto(
     val totalSubmission: Int,
     val score: Double,
     val keywords: List<KeywordDto>,
+    val contents: List<ContentDto>,
     val userAnswer: String,
     val standardAnswer: String
 ) {
@@ -24,7 +25,8 @@ data class LongProblemGradingHistoryDto(
             problem: LongProblem,
             userAnswer: String,
             score: Double,
-            keywords: List<KeywordDto>
+            keywords: List<KeywordDto>,
+            contents: List<ContentDto>
         ): LongProblemGradingHistoryDto {
             val tags = problem.problemTags.map {
                 it.tag
@@ -48,6 +50,7 @@ data class LongProblemGradingHistoryDto(
                 scoreList.size,
                 score,
                 keywords,
+                contents,
                 userAnswer,
                 problem.standardAnswer
             )

--- a/src/main/kotlin/io/csbroker/apiserver/service/UserAnswerService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/UserAnswerService.kt
@@ -32,4 +32,8 @@ interface UserAnswerService {
         userAnswerIds: List<Long>,
         userId: UUID
     )
+
+    fun removeUserAnswerById(
+        userAnswerId: Long
+    )
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/UserAnswerServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/UserAnswerServiceImpl.kt
@@ -172,6 +172,11 @@ class UserAnswerServiceImpl(
         this.userAnswerRepository.updateValidatorId(userAnswerIds, userId)
     }
 
+    @Transactional
+    override fun removeUserAnswerById(userAnswerId: Long) {
+        this.userAnswerRepository.deleteById(userAnswerId)
+    }
+
     private fun validateAssignCondition(userAnswerIds: List<Long>, userId: UUID) {
         val cnt = this.userAnswerRepository.cntUserAnswer(userAnswerIds)
         if (cnt != userAnswerIds.size) {

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
@@ -2228,4 +2228,93 @@ class AdminControllerTest {
                 )
             )
     }
+
+    @Test
+    @Order(24)
+    fun `Delete User Answer By Id 200`() {
+        // given
+        val problemInsertDto = LongProblemUpsertRequestDto(
+            "test",
+            """
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+                Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+                when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+                It has survived not only five centuries, but also the leap into electronic typesetting,
+                remaining essentially unchanged. It was popularised in the 1960s with the release of
+                Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
+                like Aldus PageMaker including versions of Lorem Ipsum.
+            """.trimIndent(),
+            """
+                It is a long established fact that a reader will be distracted by the readable content of
+                a page when looking at its layout.
+            """.trimIndent(),
+            mutableListOf("db"),
+            mutableListOf(
+                LongProblemUpsertRequestDto.GradingStandardData(
+                    "keyword-1",
+                    1.0,
+                    GradingStandardType.KEYWORD
+                ),
+                LongProblemUpsertRequestDto.GradingStandardData(
+                    "keyword-2",
+                    3.0,
+                    GradingStandardType.KEYWORD
+                ),
+                LongProblemUpsertRequestDto.GradingStandardData(
+                    "keyword-3",
+                    1.0,
+                    GradingStandardType.KEYWORD
+                ),
+                LongProblemUpsertRequestDto.GradingStandardData(
+                    "CONTENT-1",
+                    2.0,
+                    GradingStandardType.CONTENT
+                ),
+                LongProblemUpsertRequestDto.GradingStandardData(
+                    "CONTENT-2",
+                    3.0,
+                    GradingStandardType.CONTENT
+                )
+            )
+        )
+
+        val problemId = problemService.createLongProblem(problemInsertDto, "test-admin2@test.com")
+
+        val userAnswerUpsertDto = UserAnswerUpsertDto(
+            user.id!!,
+            user.id!!,
+            "test",
+            problemId
+        )
+
+        val id = this.userAnswerService.createUserAnswer(userAnswerUpsertDto)
+
+        // when
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.delete("$ADMIN_ENDPOINT/user-answers/{user_answer_id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "admin/userAnswer/deleteOne",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    RequestDocumentation.pathParameters(
+                        RequestDocumentation.parameterWithName("user_answer_id").description("유저 응답 id")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data")
+                            .type(JsonFieldType.BOOLEAN).description("성공 유무 ( 삭제 성공시 true를 return )")
+                    )
+                )
+            )
+    }
 }

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
@@ -548,7 +548,15 @@ class ProblemApiControllerTest {
                         fieldWithPath("data.keywords.[].isExist").type(JsonFieldType.BOOLEAN)
                             .description("키워드가 유저답안에 존재하는지 유무"),
                         fieldWithPath("data.keywords.[].idx").type(JsonFieldType.ARRAY)
-                            .description("키워드가 유저답안에 존재 할 때, 시작 index와 끝 index ( 존재하지 않으면 빈 배열 )")
+                            .description("키워드가 유저답안에 존재 할 때, 시작 index와 끝 index ( 존재하지 않으면 빈 배열 )"),
+                        fieldWithPath("data.contents").type(JsonFieldType.ARRAY)
+                            .description("답안에 들어가야하는 내용 채점 기준"),
+                        fieldWithPath("data.contents.[].id").type(JsonFieldType.NUMBER)
+                            .description("내용 채점 기준 id"),
+                        fieldWithPath("data.contents.[].content").type(JsonFieldType.STRING)
+                            .description("내용 채점 기준 내용"),
+                        fieldWithPath("data.contents.[].isExist").type(JsonFieldType.BOOLEAN)
+                            .description("내용 채점 기준이 유저답안에 존재하는지 유무")
                     )
                 )
             )


### PR DESCRIPTION
### Issue Number

close: N/A

### 작업 내역

- [x] 유저 응답 삭제 API 구현
- [x] 채점 결과에 내용 채점 기준 추가
- [x] API 구현 및 수정에 따른 테스트 추가 및 수정
- [x] API 구현 및 수정에 따른 문서 수정  

### 변경사항

- 의존성 목록
  -  N/A 

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [x] 문서 업데이트

### PR 특이 사항

- 내용 채점 기준과 유저 응답 삭제 API를 구현

