### PR TITLE
알림 설계 및 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -706,13 +706,101 @@ include::{snippets}/users/statsOne/http-response.adoc[]
 .Request Header
 request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
 
-이 Access Token은 Admin 권한을 가진 유저의 Access Token이며, 인증을 위해 필수적으로 포함되어야 합니다.
+이 Access Token은 인증을 위해 필수적으로 포함되어야 합니다.
 
 include::{snippets}/users/statsOne/request-headers.adoc[]
 
 .Response Body
 include::{snippets}/users/statsOne/response-body.adoc[]
 include::{snippets}/users/statsOne/response-fields.adoc[]
+
+==== Notification 조회
+
+.description
+[source]
+----
+Notification 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v1/notifications
+Req Params : page, size
+----
+
+.Sample Request
+include::{snippets}/notifications/getAll/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/notifications/getAll/http-response.adoc[]
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+
+이 Access Token은 인증을 위해 필수적으로 포함되어야 합니다.
+
+include::{snippets}/notifications/getAll/request-headers.adoc[]
+
+.Request Params
+include::{snippets}/notifications/getAll/request-parameters.adoc[]
+
+.Response Body
+include::{snippets}/notifications/getAll/response-body.adoc[]
+include::{snippets}/notifications/getAll/response-fields.adoc[]
+
+==== Notification 단건 읽음 처리
+
+.description
+[source]
+----
+Notification 읽음 처리를 위한 API입니다.
+
+HTTP Method : PUT
+End-Point   : /api/v1/notifications/read/{notification_id}
+----
+
+.Sample Request
+include::{snippets}/notifications/readOne/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/notifications/readOne/http-response.adoc[]
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+
+이 Access Token은 인증을 위해 필수적으로 포함되어야 합니다.
+
+include::{snippets}/notifications/getAll/request-headers.adoc[]
+
+.Response Body
+include::{snippets}/notifications/readOne/response-body.adoc[]
+include::{snippets}/notifications/readOne/response-fields.adoc[]
+
+==== Notification 다건 읽음 처리
+
+.description
+[source]
+----
+Notification 여러건의 읽음 처리를 위한 API입니다.
+
+HTTP Method : PUT
+End-Point   : /api/v1/notifications/read
+----
+
+.Sample Request
+include::{snippets}/notifications/readBulk/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/notifications/readBulk/http-response.adoc[]
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+
+이 Access Token은 인증을 위해 필수적으로 포함되어야 합니다.
+
+include::{snippets}/notifications/getAll/request-headers.adoc[]
+
+.Response Body
+include::{snippets}/notifications/readBulk/response-body.adoc[]
+include::{snippets}/notifications/readBulk/response-fields.adoc[]
 
 == Back-Office APIs
 
@@ -1347,3 +1435,55 @@ include::{snippets}/admin/user/admin/search//http-response.adoc[]
 .Response Body
 include::{snippets}/admin/user/admin/search/response-body.adoc[]
 include::{snippets}/admin/user/admin/search/response-fields.adoc[]
+
+=== Notification API ( /api/admin/notification )
+
+==== Notification 생성
+
+.description
+[source]
+----
+Notification 생성을 위한 API입니다.
+
+HTTP Method : POST
+End-Point   : /api/admin/notification
+----
+
+.Sample Request
+include::{snippets}/admin/notifications/insert/http-request.adoc[]
+
+.Request Body
+include::{snippets}/admin/notifications/insert/request-body.adoc[]
+include::{snippets}/admin/notifications/insert/request-fields.adoc[]
+
+.Sample Response
+include::{snippets}/admin/notifications/insert/http-response.adoc[]
+
+.Response Body
+include::{snippets}/admin/notifications/insert/response-body.adoc[]
+include::{snippets}/admin/notifications/insert/response-fields.adoc[]
+
+==== Notification 다중 생성
+
+.description
+[source]
+----
+Notification 다중 생성을 위한 API입니다.
+
+HTTP Method : POST
+End-Point   : /api/admin/notifications
+----
+
+.Sample Request
+include::{snippets}/admin/notifications/bulkInsert/http-request.adoc[]
+
+.Request Body
+include::{snippets}/admin/notifications/bulkInsert/request-body.adoc[]
+include::{snippets}/admin/notifications/bulkInsert/request-fields.adoc[]
+
+.Sample Response
+include::{snippets}/admin/notifications/bulkInsert/http-response.adoc[]
+
+.Response Body
+include::{snippets}/admin/notifications/bulkInsert/response-body.adoc[]
+include::{snippets}/admin/notifications/bulkInsert/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -714,6 +714,8 @@ include::{snippets}/users/statsOne/request-headers.adoc[]
 include::{snippets}/users/statsOne/response-body.adoc[]
 include::{snippets}/users/statsOne/response-fields.adoc[]
 
+=== Notification API ( /api/v1/notifications )
+
 ==== Notification 조회
 
 .description
@@ -801,6 +803,36 @@ include::{snippets}/notifications/getAll/request-headers.adoc[]
 .Response Body
 include::{snippets}/notifications/readBulk/response-body.adoc[]
 include::{snippets}/notifications/readBulk/response-fields.adoc[]
+
+==== 읽지않은 Notification 개수 조회
+
+.description
+[source]
+----
+읽지않은 Notification 개수 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v1/notifications/count
+Req Params : page, size
+----
+
+.Sample Request
+include::{snippets}/notifications/count/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/notifications/count/http-response.adoc[]
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+
+이 Access Token은 인증을 위해 필수적으로 포함되어야 합니다.
+
+include::{snippets}/notifications/count/request-headers.adoc[]
+
+.Response Body
+include::{snippets}/notifications/count/response-body.adoc[]
+include::{snippets}/notifications/count/response-fields.adoc[]
+
 
 == Back-Office APIs
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -813,7 +813,6 @@ include::{snippets}/notifications/readBulk/response-fields.adoc[]
 
 HTTP Method : GET
 End-Point   : /api/v1/notifications/count
-Req Params : page, size
 ----
 
 .Sample Request

--- a/src/main/kotlin/io/csbroker/apiserver/common/config/security/JwtConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/security/JwtConfig.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.common.config.security
 
-import io.csbroker.apiserver.auth.AuthTokenProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/io/csbroker/apiserver/common/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/security/SecurityConfig.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.common.config.security
 
-import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.common.config.properties.AppProperties
 import io.csbroker.apiserver.common.config.properties.CorsProperties
 import io.csbroker.apiserver.common.enums.Role

--- a/src/main/kotlin/io/csbroker/apiserver/common/filter/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/filter/TokenAuthenticationFilter.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.common.filter
 
-import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.common.util.getAccessToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter

--- a/src/main/kotlin/io/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/handler/OAuth2AuthenticationSuccessHandler.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.common.handler
 
-import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.auth.OAuth2UserInfoFactory
 import io.csbroker.apiserver.auth.ProviderType
 import io.csbroker.apiserver.common.config.properties.AppProperties

--- a/src/main/kotlin/io/csbroker/apiserver/common/util/UuidUtil.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/util/UuidUtil.kt
@@ -1,0 +1,14 @@
+package io.csbroker.apiserver.common.util
+
+import java.nio.ByteBuffer
+import java.util.UUID
+
+fun uuidAsByte(uuid: UUID?): ByteArray? {
+    if (uuid == null) {
+        return null
+    }
+    val byteBufferWrapper = ByteBuffer.wrap(ByteArray(16))
+    byteBufferWrapper.putLong(uuid.mostSignificantBits)
+    byteBufferWrapper.putLong(uuid.leastSignificantBits)
+    return byteBufferWrapper.array()
+}

--- a/src/main/kotlin/io/csbroker/apiserver/controller/AdminController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/AdminController.kt
@@ -5,6 +5,8 @@ import io.csbroker.apiserver.common.enums.ErrorCode
 import io.csbroker.apiserver.common.exception.ConditionConflictException
 import io.csbroker.apiserver.dto.common.ApiResponse
 import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
+import io.csbroker.apiserver.dto.notification.NotificationBulkInsertDto
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
 import io.csbroker.apiserver.dto.problem.ProblemDeleteRequestDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemResponseDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemSearchResponseDto
@@ -22,6 +24,7 @@ import io.csbroker.apiserver.dto.useranswer.UserAnswerLabelRequestDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerResponseDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerSearchResponseDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerUpsertDto
+import io.csbroker.apiserver.service.NotificationService
 import io.csbroker.apiserver.service.ProblemService
 import io.csbroker.apiserver.service.UserAnswerService
 import io.csbroker.apiserver.service.UserService
@@ -42,7 +45,8 @@ import org.springframework.web.bind.annotation.RestController
 class AdminController(
     private val problemService: ProblemService,
     private val userAnswerService: UserAnswerService,
-    private val userService: UserService
+    private val userService: UserService,
+    private val notificationService: NotificationService
 ) {
     @GetMapping("/users/admin")
     fun findAdminUsers(): ApiResponse<List<AdminUserInfoResponseDto>> {
@@ -290,5 +294,27 @@ class AdminController(
         }
 
         return ApiResponse.success(UpsertSuccessResponseDto(size = assignUserAnswerDto.userAnswerIds.size))
+    }
+
+    @PostMapping("/notification")
+    fun createNotification(
+        @RequestBody createNotificationDto: NotificationRequestDto
+    ): ApiResponse<UpsertSuccessResponseDto> {
+        return ApiResponse.success(
+            UpsertSuccessResponseDto(
+                id = notificationService.createNotification(createNotificationDto)
+            )
+        )
+    }
+
+    @PostMapping("/notifications")
+    fun createBulkNotifications(
+        @RequestBody notificationBulkInsertDto: NotificationBulkInsertDto
+    ): ApiResponse<UpsertSuccessResponseDto> {
+        return ApiResponse.success(
+            UpsertSuccessResponseDto(
+                size = notificationService.createBulkNotification(notificationBulkInsertDto.content)
+            )
+        )
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/controller/CommonController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/CommonController.kt
@@ -12,8 +12,8 @@ import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 

--- a/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
@@ -5,6 +5,7 @@ import io.csbroker.apiserver.dto.common.ApiResponse
 import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
 import io.csbroker.apiserver.dto.notification.NotificationBulkReadDto
 import io.csbroker.apiserver.dto.notification.NotificationPageResponseDto
+import io.csbroker.apiserver.dto.notification.UnReadNotificationCountDto
 import io.csbroker.apiserver.service.NotificationService
 import org.springframework.data.domain.Pageable
 import org.springframework.security.core.userdetails.User
@@ -25,6 +26,12 @@ class NotificationController(
     fun getNotifications(@LoginUser loginUser: User, pageable: Pageable): ApiResponse<NotificationPageResponseDto> {
         val notifications = notificationService.getNotification(loginUser.username, pageable)
         return ApiResponse.success(NotificationPageResponseDto(notifications))
+    }
+
+    @GetMapping("/count")
+    fun getUnreadNotificationCount(@LoginUser loginUser: User): ApiResponse<UnReadNotificationCountDto> {
+        val count = notificationService.getUnreadNotificationCount(loginUser.username)
+        return ApiResponse.success(UnReadNotificationCountDto(count))
     }
 
     @PutMapping("/read")

--- a/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
@@ -8,6 +8,8 @@ import io.csbroker.apiserver.dto.notification.NotificationReadResponseDto
 import io.csbroker.apiserver.dto.notification.UnReadNotificationCountDto
 import io.csbroker.apiserver.service.NotificationService
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -23,7 +25,14 @@ class NotificationController(
 ) {
 
     @GetMapping
-    fun getNotifications(@LoginUser loginUser: User, pageable: Pageable): ApiResponse<NotificationPageResponseDto> {
+    fun getNotifications(
+        @LoginUser loginUser: User,
+        @PageableDefault(
+            size = 10,
+            sort = ["createdAt"],
+            direction = Sort.Direction.DESC
+        ) pageable: Pageable
+    ): ApiResponse<NotificationPageResponseDto> {
         val notifications = notificationService.getNotification(loginUser.username, pageable)
         return ApiResponse.success(NotificationPageResponseDto(notifications))
     }

--- a/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
@@ -1,0 +1,59 @@
+package io.csbroker.apiserver.controller
+
+import io.csbroker.apiserver.auth.LoginUser
+import io.csbroker.apiserver.dto.common.ApiResponse
+import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
+import io.csbroker.apiserver.dto.notification.NotificationBulkReadDto
+import io.csbroker.apiserver.dto.notification.NotificationPageResponseDto
+import io.csbroker.apiserver.service.NotificationService
+import org.springframework.data.domain.Pageable
+import org.springframework.security.core.userdetails.User
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+class NotificationController(
+    private val notificationService: NotificationService
+) {
+
+    @GetMapping
+    fun getNotifications(@LoginUser loginUser: User, pageable: Pageable): ApiResponse<NotificationPageResponseDto> {
+        val notifications = notificationService.getNotification(loginUser.username, pageable)
+        return ApiResponse.success(NotificationPageResponseDto(notifications))
+    }
+
+    @PutMapping("/read")
+    fun readNotifications(
+        @LoginUser loginUser: User,
+        @RequestBody notificationBulkReadDto: NotificationBulkReadDto
+    ): ApiResponse<UpsertSuccessResponseDto> {
+        return ApiResponse.success(
+            UpsertSuccessResponseDto(
+                size = notificationService.readNotifications(
+                    loginUser.username,
+                    notificationBulkReadDto.ids
+                )
+            )
+        )
+    }
+
+    @PutMapping("/read/{id}")
+    fun readNotificationById(
+        @LoginUser loginUser: User,
+        @PathVariable("id") id: Long
+    ): ApiResponse<UpsertSuccessResponseDto> {
+        return ApiResponse.success(
+            UpsertSuccessResponseDto(
+                id = notificationService.readNotificationById(
+                    loginUser.username,
+                    id
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/NotificationController.kt
@@ -2,9 +2,9 @@ package io.csbroker.apiserver.controller
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.dto.common.ApiResponse
-import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
 import io.csbroker.apiserver.dto.notification.NotificationBulkReadDto
 import io.csbroker.apiserver.dto.notification.NotificationPageResponseDto
+import io.csbroker.apiserver.dto.notification.NotificationReadResponseDto
 import io.csbroker.apiserver.dto.notification.UnReadNotificationCountDto
 import io.csbroker.apiserver.service.NotificationService
 import org.springframework.data.domain.Pageable
@@ -38,29 +38,17 @@ class NotificationController(
     fun readNotifications(
         @LoginUser loginUser: User,
         @RequestBody notificationBulkReadDto: NotificationBulkReadDto
-    ): ApiResponse<UpsertSuccessResponseDto> {
-        return ApiResponse.success(
-            UpsertSuccessResponseDto(
-                size = notificationService.readNotifications(
-                    loginUser.username,
-                    notificationBulkReadDto.ids
-                )
-            )
-        )
+    ): ApiResponse<NotificationReadResponseDto> {
+        notificationService.readNotifications(loginUser.username, notificationBulkReadDto.ids)
+        return ApiResponse.success(NotificationReadResponseDto())
     }
 
     @PutMapping("/read/{id}")
     fun readNotificationById(
         @LoginUser loginUser: User,
         @PathVariable("id") id: Long
-    ): ApiResponse<UpsertSuccessResponseDto> {
-        return ApiResponse.success(
-            UpsertSuccessResponseDto(
-                id = notificationService.readNotificationById(
-                    loginUser.username,
-                    id
-                )
-            )
-        )
+    ): ApiResponse<NotificationReadResponseDto> {
+        notificationService.readNotificationById(loginUser.username, id)
+        return ApiResponse.success(NotificationReadResponseDto())
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationBulkInsertDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationBulkInsertDto.kt
@@ -1,0 +1,5 @@
+package io.csbroker.apiserver.dto.notification
+
+data class NotificationBulkInsertDto(
+    val content: List<NotificationRequestDto>
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationBulkReadDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationBulkReadDto.kt
@@ -1,0 +1,5 @@
+package io.csbroker.apiserver.dto.notification
+
+data class NotificationBulkReadDto(
+    val ids: List<Long>
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationPageResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationPageResponseDto.kt
@@ -1,0 +1,22 @@
+package io.csbroker.apiserver.dto.notification
+
+import io.csbroker.apiserver.model.Notification
+import org.springframework.data.domain.Page
+
+data class NotificationPageResponseDto(
+    val contents: List<NotificationResponseDto>,
+    val currentPage: Int,
+    val totalPages: Int,
+    val totalElements: Long,
+    val numberOfElements: Int,
+    val size: Int
+) {
+    constructor(pageData: Page<Notification>) : this(
+        pageData.content.map { it.toNotificationResponseDto() },
+        pageData.pageable.pageNumber,
+        pageData.totalPages,
+        pageData.totalElements,
+        pageData.numberOfElements,
+        pageData.size
+    )
+}

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationReadResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationReadResponseDto.kt
@@ -1,0 +1,5 @@
+package io.csbroker.apiserver.dto.notification
+
+data class NotificationReadResponseDto(
+    val success: Boolean = true
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationRequestDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationRequestDto.kt
@@ -1,0 +1,9 @@
+package io.csbroker.apiserver.dto.notification
+
+import java.util.UUID
+
+data class NotificationRequestDto(
+    val content: String,
+    val userId: UUID,
+    val link: String
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
@@ -1,0 +1,8 @@
+package io.csbroker.apiserver.dto.notification
+
+data class NotificationResponseDto(
+    val id: Long,
+    val content: String,
+    val link: Any,
+    val isRead: Boolean,
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
@@ -4,5 +4,5 @@ data class NotificationResponseDto(
     val id: Long,
     val content: String,
     val link: String,
-    val isRead: Boolean,
+    val isRead: Boolean
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
@@ -1,8 +1,11 @@
 package io.csbroker.apiserver.dto.notification
 
+import java.time.LocalDateTime
+
 data class NotificationResponseDto(
     val id: Long,
     val content: String,
     val link: String,
-    val isRead: Boolean
+    val isRead: Boolean,
+    val createdAt: LocalDateTime
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/NotificationResponseDto.kt
@@ -3,6 +3,6 @@ package io.csbroker.apiserver.dto.notification
 data class NotificationResponseDto(
     val id: Long,
     val content: String,
-    val link: Any,
+    val link: String,
     val isRead: Boolean,
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/notification/UnReadNotificationCountDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/notification/UnReadNotificationCountDto.kt
@@ -1,0 +1,5 @@
+package io.csbroker.apiserver.dto.notification
+
+data class UnReadNotificationCountDto(
+    val count: Long
+)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/user/UserInfoResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/user/UserInfoResponseDto.kt
@@ -1,7 +1,7 @@
 package io.csbroker.apiserver.dto.user
 
-import io.csbroker.apiserver.common.enums.Role
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.csbroker.apiserver.common.enums.Role
 import java.util.UUID
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/io/csbroker/apiserver/model/Notification.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/Notification.kt
@@ -1,0 +1,50 @@
+package io.csbroker.apiserver.model
+
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+import io.csbroker.apiserver.dto.notification.NotificationResponseDto
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "notification")
+class Notification(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    val id: Long? = null,
+
+    @Column(name = "content", columnDefinition = "VARCHAR(100)")
+    val content: String,
+
+    @Column(name = "link", columnDefinition = "VARCHAR(300)")
+    val link: String,
+
+    @Column(name = "is_read")
+    val isRead: Boolean = false,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User
+) : BaseEntity() {
+    constructor(notificationRequestDto: NotificationRequestDto, user: User) : this(
+        content = notificationRequestDto.content,
+        link = notificationRequestDto.link,
+        user = user
+    )
+
+    fun toNotificationResponseDto(): NotificationResponseDto {
+        return NotificationResponseDto(
+            this.id!!,
+            this.content,
+            this.link,
+            this.isRead
+        )
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/model/Notification.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/Notification.kt
@@ -44,7 +44,8 @@ class Notification(
             this.id!!,
             this.content,
             this.link,
-            this.isRead
+            this.isRead,
+            this.createdAt!!
         )
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/model/User.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/User.kt
@@ -80,7 +80,10 @@ class User(
     val assignedToValidateAnswers: MutableList<UserAnswer> = mutableListOf(),
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
-    val gradingHistories: MutableList<GradingHistory> = mutableListOf()
+    val gradingHistories: MutableList<GradingHistory> = mutableListOf(),
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    val notifications: MutableList<Notification> = mutableListOf()
 ) : BaseEntity() {
     fun updateInfo(userUpdateRequestDto: UserUpdateRequestDto) {
         this.profileImageUrl = userUpdateRequestDto.profileImageUrl ?: this.profileImageUrl

--- a/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
@@ -19,4 +19,7 @@ interface NotificationRepository : JpaRepository<Notification, Long>, Notificati
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = TRUE WHERE n.id = :id AND n.user.id = :userId")
     fun setIsReadById(@Param("userId") userId: UUID, @Param("id") id: Long)
+
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.user.id = :userId AND n.isRead = FALSE")
+    fun countUnReadByUserId(@Param("userId") userId: UUID): Long
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
@@ -14,11 +14,11 @@ interface NotificationRepository : JpaRepository<Notification, Long>, Notificati
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = TRUE WHERE n.id IN :notificationIds AND n.user.id = :userId")
-    fun setIsReadByIdIn(@Param("userId") userId: UUID, @Param("notificationIds") notificationIds: List<Long>)
+    fun setIsReadByIdIn(@Param("userId") userId: UUID, @Param("notificationIds") notificationIds: List<Long>): Int
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = TRUE WHERE n.id = :id AND n.user.id = :userId")
-    fun setIsReadById(@Param("userId") userId: UUID, @Param("id") id: Long)
+    fun setIsReadById(@Param("userId") userId: UUID, @Param("id") id: Long): Int
 
     @Query("SELECT COUNT(n) FROM Notification n WHERE n.user.id = :userId AND n.isRead = FALSE")
     fun countUnReadByUserId(@Param("userId") userId: UUID): Long

--- a/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepository.kt
@@ -1,0 +1,22 @@
+package io.csbroker.apiserver.repository
+
+import io.csbroker.apiserver.model.Notification
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface NotificationRepository : JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+    fun findByUserId(userId: UUID, pageable: Pageable): Page<Notification>
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = TRUE WHERE n.id IN :notificationIds AND n.user.id = :userId")
+    fun setIsReadByIdIn(@Param("userId") userId: UUID, @Param("notificationIds") notificationIds: List<Long>)
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = TRUE WHERE n.id = :id AND n.user.id = :userId")
+    fun setIsReadById(@Param("userId") userId: UUID, @Param("id") id: Long)
+}

--- a/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepositoryCustom.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepositoryCustom.kt
@@ -1,0 +1,7 @@
+package io.csbroker.apiserver.repository
+
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+
+interface NotificationRepositoryCustom {
+    fun insertBulkNotifications(notifications: List<NotificationRequestDto>)
+}

--- a/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/NotificationRepositoryCustomImpl.kt
@@ -1,0 +1,41 @@
+package io.csbroker.apiserver.repository
+
+import io.csbroker.apiserver.common.util.uuidAsByte
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.PreparedStatement
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+class NotificationRepositoryCustomImpl(
+    private val jdbcTemplate: JdbcTemplate
+) : NotificationRepositoryCustom {
+    override fun insertBulkNotifications(notifications: List<NotificationRequestDto>) {
+        val sql = """
+            INSERT INTO notification
+            (content, link, is_read, user_id, created_at, updated_at)
+            VALUES
+            (?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            object : BatchPreparedStatementSetter {
+                override fun setValues(ps: PreparedStatement, i: Int) {
+                    val notification = notifications[i]
+                    ps.setString(1, notification.content)
+                    ps.setString(2, notification.link)
+                    ps.setBoolean(3, false)
+                    ps.setBytes(4, uuidAsByte(notification.userId))
+                    ps.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()))
+                    ps.setTimestamp(6, Timestamp.valueOf(LocalDateTime.now()))
+                }
+
+                override fun getBatchSize(): Int {
+                    return notifications.size
+                }
+            }
+        )
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
@@ -1,5 +1,7 @@
 package io.csbroker.apiserver.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
 import io.csbroker.apiserver.dto.problem.GradingHistoryStats
 import io.csbroker.apiserver.dto.problem.ProblemResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
@@ -8,8 +10,6 @@ import io.csbroker.apiserver.model.QProblem.problem
 import io.csbroker.apiserver.model.QProblemTag.problemTag
 import io.csbroker.apiserver.model.QTag.tag
 import io.csbroker.apiserver.model.QUser.user
-import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/io/csbroker/apiserver/repository/UserAnswerRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/UserAnswerRepositoryCustomImpl.kt
@@ -1,22 +1,21 @@
 package io.csbroker.apiserver.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import io.csbroker.apiserver.common.util.uuidAsByte
 import io.csbroker.apiserver.dto.useranswer.UserAnswerUpsertDto
 import io.csbroker.apiserver.model.QLongProblem.longProblem
 import io.csbroker.apiserver.model.QUser.user
 import io.csbroker.apiserver.model.QUserAnswer.userAnswer
 import io.csbroker.apiserver.model.UserAnswer
-import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.jdbc.core.BatchPreparedStatementSetter
 import org.springframework.jdbc.core.JdbcTemplate
-import java.nio.ByteBuffer
 import java.sql.PreparedStatement
 import java.sql.Timestamp
 import java.time.LocalDateTime
-import java.util.UUID
 
 class UserAnswerRepositoryCustomImpl(
     private val jdbcTemplate: JdbcTemplate,
@@ -127,15 +126,5 @@ class UserAnswerRepositoryCustomImpl(
 
     private fun userAnswerValidated(isValidated: Boolean?): BooleanExpression? {
         return if (isValidated == null) null else userAnswer.isValidated.eq(isValidated)
-    }
-
-    private fun uuidAsByte(uuid: UUID?): ByteArray? {
-        if (uuid == null) {
-            return null
-        }
-        val byteBufferWrapper = ByteBuffer.wrap(ByteArray(16))
-        byteBufferWrapper.putLong(uuid.mostSignificantBits)
-        byteBufferWrapper.putLong(uuid.leastSignificantBits)
-        return byteBufferWrapper.array()
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
@@ -1,0 +1,14 @@
+package io.csbroker.apiserver.service
+
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+import io.csbroker.apiserver.model.Notification
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface NotificationService {
+    fun createNotification(notificationRequestDto: NotificationRequestDto): Long
+    fun createBulkNotification(notificationRequestListDto: List<NotificationRequestDto>): Int
+    fun getNotification(email: String, page: Pageable): Page<Notification>
+    fun readNotifications(email: String, notificationIds: List<Long>): Int
+    fun readNotificationById(email: String, id: Long): Long
+}

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
@@ -9,7 +9,7 @@ interface NotificationService {
     fun createNotification(notificationRequestDto: NotificationRequestDto): Long
     fun createBulkNotification(notificationRequestListDto: List<NotificationRequestDto>): Int
     fun getNotification(email: String, page: Pageable): Page<Notification>
-    fun readNotifications(email: String, notificationIds: List<Long>): Int
-    fun readNotificationById(email: String, id: Long): Long
+    fun readNotifications(email: String, notificationIds: List<Long>)
+    fun readNotificationById(email: String, id: Long)
     fun getUnreadNotificationCount(email: String): Long
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationService.kt
@@ -11,4 +11,5 @@ interface NotificationService {
     fun getNotification(email: String, page: Pageable): Page<Notification>
     fun readNotifications(email: String, notificationIds: List<Long>): Int
     fun readNotificationById(email: String, id: Long): Long
+    fun getUnreadNotificationCount(email: String): Long
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
@@ -58,4 +58,11 @@ class NotificationServiceImpl(
 
         return id
     }
+
+    override fun getUnreadNotificationCount(email: String): Long {
+        val findUser = userRepository.findByEmail(email)
+            ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
+
+        return notificationRepository.countUnReadByUserId(findUser.id!!)
+    }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
@@ -40,23 +40,27 @@ class NotificationServiceImpl(
     }
 
     @Transactional
-    override fun readNotifications(email: String, notificationIds: List<Long>): Int {
+    override fun readNotifications(email: String, notificationIds: List<Long>) {
         val findUser = userRepository.findByEmail(email)
             ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
 
-        notificationRepository.setIsReadByIdIn(findUser.id!!, notificationIds)
+        val updatedCount = notificationRepository.setIsReadByIdIn(findUser.id!!, notificationIds)
 
-        return notificationIds.size
+        if (updatedCount != notificationIds.size) {
+            throw EntityNotFoundException("해당하는 알림을 찾을 수 없습니다.")
+        }
     }
 
     @Transactional
-    override fun readNotificationById(email: String, id: Long): Long {
+    override fun readNotificationById(email: String, id: Long) {
         val findUser = userRepository.findByEmail(email)
             ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
 
-        notificationRepository.setIsReadById(findUser.id!!, id)
+        val updatedCount = notificationRepository.setIsReadById(findUser.id!!, id)
 
-        return id
+        if (updatedCount == 0) {
+            throw EntityNotFoundException("해당하는 알림을 찾을 수 없습니다.")
+        }
     }
 
     override fun getUnreadNotificationCount(email: String): Long {

--- a/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/NotificationServiceImpl.kt
@@ -1,0 +1,61 @@
+package io.csbroker.apiserver.service
+
+import io.csbroker.apiserver.common.exception.EntityNotFoundException
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+import io.csbroker.apiserver.model.Notification
+import io.csbroker.apiserver.repository.NotificationRepository
+import io.csbroker.apiserver.repository.UserRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Service
+class NotificationServiceImpl(
+    private val notificationRepository: NotificationRepository,
+    private val userRepository: UserRepository
+) : NotificationService {
+    @Transactional
+    override fun createNotification(notificationRequestDto: NotificationRequestDto): Long {
+        val findUser = userRepository.findByIdOrNull(notificationRequestDto.userId)
+            ?: throw EntityNotFoundException("${notificationRequestDto.userId} 에 해당하는 유저를 찾을 수 없습니다.")
+
+        val notification = Notification(notificationRequestDto, findUser)
+
+        return notificationRepository.save(notification).id!!
+    }
+
+    @Transactional
+    override fun createBulkNotification(notificationRequestListDto: List<NotificationRequestDto>): Int {
+        notificationRepository.insertBulkNotifications(notificationRequestListDto)
+        return notificationRequestListDto.size
+    }
+
+    override fun getNotification(email: String, page: Pageable): Page<Notification> {
+        val findUser = userRepository.findByEmail(email)
+            ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
+
+        return notificationRepository.findByUserId(findUser.id!!, page)
+    }
+
+    @Transactional
+    override fun readNotifications(email: String, notificationIds: List<Long>): Int {
+        val findUser = userRepository.findByEmail(email)
+            ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
+
+        notificationRepository.setIsReadByIdIn(findUser.id!!, notificationIds)
+
+        return notificationIds.size
+    }
+
+    @Transactional
+    override fun readNotificationById(email: String, id: Long): Long {
+        val findUser = userRepository.findByEmail(email)
+            ?: throw EntityNotFoundException("$email 에 해당하는 유저를 찾을 수 없습니다.")
+
+        notificationRepository.setIsReadById(findUser.id!!, id)
+
+        return id
+    }
+}

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
@@ -1,17 +1,17 @@
 package io.csbroker.apiserver.e2e
 
-import io.csbroker.apiserver.auth.AuthTokenProvider
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.csbroker.apiserver.auth.ProviderType
 import io.csbroker.apiserver.common.enums.GradingStandardType
 import io.csbroker.apiserver.common.enums.Role
+import io.csbroker.apiserver.dto.problem.ProblemDeleteRequestDto
+import io.csbroker.apiserver.dto.problem.longproblem.LongProblemUpsertRequestDto
+import io.csbroker.apiserver.dto.problem.multiplechoiceproblem.MultipleChoiceProblemUpsertRequestDto
+import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemUpsertRequestDto
+import io.csbroker.apiserver.dto.useranswer.AssignUserAnswerDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerBatchInsertDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerLabelRequestDto
 import io.csbroker.apiserver.dto.useranswer.UserAnswerUpsertDto
-import io.csbroker.apiserver.dto.problem.longproblem.LongProblemUpsertRequestDto
-import io.csbroker.apiserver.dto.problem.multiplechoiceproblem.MultipleChoiceProblemUpsertRequestDto
-import io.csbroker.apiserver.dto.problem.ProblemDeleteRequestDto
-import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemUpsertRequestDto
-import io.csbroker.apiserver.dto.useranswer.AssignUserAnswerDto
 import io.csbroker.apiserver.model.Tag
 import io.csbroker.apiserver.model.User
 import io.csbroker.apiserver.repository.LongProblemRepository
@@ -22,7 +22,6 @@ import io.csbroker.apiserver.repository.UserAnswerRepository
 import io.csbroker.apiserver.repository.UserRepository
 import io.csbroker.apiserver.service.ProblemService
 import io.csbroker.apiserver.service.UserAnswerService
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.CoreMatchers
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Order

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/AuthControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/AuthControllerTest.kt
@@ -1,5 +1,6 @@
 package io.csbroker.apiserver.e2e
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.common.enums.Role
 import io.csbroker.apiserver.dto.auth.PasswordChangeMailRequestDto
@@ -8,7 +9,6 @@ import io.csbroker.apiserver.dto.user.UserLoginRequestDto
 import io.csbroker.apiserver.dto.user.UserSignUpDto
 import io.csbroker.apiserver.repository.common.REFRESH_TOKEN
 import io.csbroker.apiserver.repository.common.RedisRepository
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -255,7 +255,7 @@ class NotificationControllerTest {
                         PayloadDocumentation.fieldWithPath("data.numberOfElements")
                             .type(JsonFieldType.NUMBER).description("현재 페이지의 알림 개수"),
                         PayloadDocumentation.fieldWithPath("data.size")
-                            .type(JsonFieldType.NUMBER).description("한 페이지에 보여줄 알림 개수"),
+                            .type(JsonFieldType.NUMBER).description("한 페이지에 보여줄 알림 개수")
                     )
                 )
             )

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -351,4 +351,49 @@ class NotificationControllerTest {
                 )
             )
     }
+
+    @Test
+    @Order(6)
+    fun `Get Un Read Notifications 200`() {
+        // given
+        notificationRepository.saveAll(
+            (1..10).map {
+                Notification(
+                    content = "test content $it",
+                    user = this.user,
+                    link = "https://dev.csbroker.io"
+                )
+            }.toList()
+        )
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.get("$NOTIFICATION_ENDPOINT/count")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "notifications/count",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    HeaderDocumentation.requestHeaders(
+                        HeaderDocumentation.headerWithName(HttpHeaders.AUTHORIZATION)
+                            .description("인증을 위한 Access 토큰")
+                            .optional()
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.count")
+                            .type(JsonFieldType.NUMBER).description("읽지 않은 알림 개수")
+                    )
+                )
+            )
+    }
 }

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -292,8 +292,8 @@ class NotificationControllerTest {
                     PayloadDocumentation.responseFields(
                         PayloadDocumentation.fieldWithPath("status")
                             .type(JsonFieldType.STRING).description("결과 상태"),
-                        PayloadDocumentation.fieldWithPath("data.id")
-                            .type(JsonFieldType.NUMBER).description("알림 ID")
+                        PayloadDocumentation.fieldWithPath("data.success")
+                            .type(JsonFieldType.BOOLEAN).description("읽음 처리 성공 여부")
                     )
                 )
             )
@@ -345,8 +345,8 @@ class NotificationControllerTest {
                     PayloadDocumentation.responseFields(
                         PayloadDocumentation.fieldWithPath("status")
                             .type(JsonFieldType.STRING).description("결과 상태"),
-                        PayloadDocumentation.fieldWithPath("data.size")
-                            .type(JsonFieldType.NUMBER).description("읽음 처리된 알림 개수")
+                        PayloadDocumentation.fieldWithPath("data.success")
+                            .type(JsonFieldType.BOOLEAN).description("읽음 처리 성공 여부")
                     )
                 )
             )

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -66,8 +66,8 @@ class NotificationControllerTest {
     @BeforeAll
     fun setup() {
         val user = User(
-            email = "test-admin2@test.com",
-            username = "test-admin2",
+            email = "test-admin3@test.com",
+            username = "test-admin3",
             providerType = ProviderType.LOCAL,
             role = Role.ROLE_ADMIN
         )
@@ -79,7 +79,7 @@ class NotificationControllerTest {
         val now = Date()
 
         val accessToken = tokenProvider.createAuthToken(
-            "test-admin2@test.com",
+            "test-admin3@test.com",
             expiry = Date(now.time + 6000000),
             role = Role.ROLE_ADMIN.code
         )

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -246,6 +246,8 @@ class NotificationControllerTest {
                             .type(JsonFieldType.STRING).description("알림 링크"),
                         PayloadDocumentation.fieldWithPath("data.contents.[].isRead")
                             .type(JsonFieldType.BOOLEAN).description("알림 읽음 여부"),
+                        PayloadDocumentation.fieldWithPath("data.contents.[].createdAt")
+                            .type(JsonFieldType.STRING).description("알림 생성 시간"),
                         PayloadDocumentation.fieldWithPath("data.currentPage")
                             .type(JsonFieldType.NUMBER).description("요청한 현재 페이지"),
                         PayloadDocumentation.fieldWithPath("data.totalPages")

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/NotificationControllerTest.kt
@@ -1,0 +1,354 @@
+package io.csbroker.apiserver.e2e
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.csbroker.apiserver.auth.AuthTokenProvider
+import io.csbroker.apiserver.auth.ProviderType
+import io.csbroker.apiserver.common.enums.Role
+import io.csbroker.apiserver.dto.notification.NotificationBulkInsertDto
+import io.csbroker.apiserver.dto.notification.NotificationBulkReadDto
+import io.csbroker.apiserver.dto.notification.NotificationRequestDto
+import io.csbroker.apiserver.model.Notification
+import io.csbroker.apiserver.model.User
+import io.csbroker.apiserver.repository.NotificationRepository
+import io.csbroker.apiserver.repository.UserRepository
+import org.hamcrest.CoreMatchers
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.restdocs.headers.HeaderDocumentation
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.restdocs.request.RequestDocumentation
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.Date
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificationControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var tokenProvider: AuthTokenProvider
+
+    private lateinit var user: User
+
+    private lateinit var token: String
+
+    private val ADMIN_ENDPOINT = "/api/admin"
+
+    private val NOTIFICATION_ENDPOINT = "/api/v1/notifications"
+
+    @BeforeAll
+    fun setup() {
+        val user = User(
+            email = "test-admin2@test.com",
+            username = "test-admin2",
+            providerType = ProviderType.LOCAL,
+            role = Role.ROLE_ADMIN
+        )
+
+        userRepository.save(user)
+
+        this.user = user
+
+        val now = Date()
+
+        val accessToken = tokenProvider.createAuthToken(
+            "test-admin2@test.com",
+            expiry = Date(now.time + 6000000),
+            role = Role.ROLE_ADMIN.code
+        )
+
+        this.token = accessToken.token
+    }
+
+    @Test
+    @Order(1)
+    fun `Create Notification 200`() {
+        // given
+        val notificationRequestDto = NotificationRequestDto(
+            content = "test content",
+            userId = user.id!!,
+            link = "https://dev.csbroker.io"
+        )
+
+        val notificationRequestDtoString = objectMapper.writeValueAsString(notificationRequestDto)
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("$ADMIN_ENDPOINT/notification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(notificationRequestDtoString)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "admin/notifications/insert",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("content").type(JsonFieldType.STRING)
+                            .description("알림 내용"),
+                        PayloadDocumentation.fieldWithPath("userId").type(JsonFieldType.STRING)
+                            .description("유저 아이디 ( UUID )"),
+                        PayloadDocumentation.fieldWithPath("link").type(JsonFieldType.STRING)
+                            .description("알림에 해당하는 링크")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.id")
+                            .type(JsonFieldType.NUMBER).description("알림 ID")
+                    )
+                )
+            )
+    }
+
+    @Test
+    @Order(2)
+    fun `Create Multiple Notification 200`() {
+        // given
+        val content = mutableListOf<NotificationRequestDto>()
+
+        for (i in 1..10) {
+            content.add(
+                NotificationRequestDto(
+                    content = "test content $i",
+                    userId = user.id!!,
+                    link = "https://dev.csbroker.io"
+                )
+            )
+        }
+
+        val bulkInsertDto = NotificationBulkInsertDto(content)
+
+        val bulkInsertDtoString = objectMapper.writeValueAsString(bulkInsertDto)
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("$ADMIN_ENDPOINT/notifications")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(bulkInsertDtoString)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "admin/notifications/bulkInsert",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("content").type(JsonFieldType.ARRAY)
+                            .description("알림 데이터"),
+                        PayloadDocumentation.fieldWithPath("content.[].content").type(JsonFieldType.STRING)
+                            .description("알림 내용"),
+                        PayloadDocumentation.fieldWithPath("content.[].userId").type(JsonFieldType.STRING)
+                            .description("유저 아이디 ( UUID )"),
+                        PayloadDocumentation.fieldWithPath("content.[].link").type(JsonFieldType.STRING)
+                            .description("알림에 해당하는 링크")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.size")
+                            .type(JsonFieldType.NUMBER).description("생성 된 알림 개수")
+                    )
+                )
+            )
+    }
+
+    @Test
+    @Order(3)
+    fun `Get Notifications 200`() {
+        // given
+        val page = 0
+        val size = 10
+
+        notificationRepository.saveAll(
+            (1..10).map {
+                Notification(
+                    content = "test content $it",
+                    user = this.user,
+                    link = "https://dev.csbroker.io"
+                )
+            }.toList()
+        )
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.get("$NOTIFICATION_ENDPOINT?page=$page&size=$size")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "notifications/getAll",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    HeaderDocumentation.requestHeaders(
+                        HeaderDocumentation.headerWithName(HttpHeaders.AUTHORIZATION)
+                            .description("인증을 위한 Access 토큰")
+                            .optional()
+                    ),
+                    RequestDocumentation.requestParameters(
+                        RequestDocumentation.parameterWithName("page").description("페이지"),
+                        RequestDocumentation.parameterWithName("size").description("가져올 문제의 개수")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.contents")
+                            .type(JsonFieldType.ARRAY).description("알림 내용 리스트"),
+                        PayloadDocumentation.fieldWithPath("data.contents.[].id")
+                            .type(JsonFieldType.NUMBER).description("알림 ID"),
+                        PayloadDocumentation.fieldWithPath("data.contents.[].content")
+                            .type(JsonFieldType.STRING).description("알림 내용"),
+                        PayloadDocumentation.fieldWithPath("data.contents.[].link")
+                            .type(JsonFieldType.STRING).description("알림 링크"),
+                        PayloadDocumentation.fieldWithPath("data.contents.[].isRead")
+                            .type(JsonFieldType.BOOLEAN).description("알림 읽음 여부"),
+                        PayloadDocumentation.fieldWithPath("data.currentPage")
+                            .type(JsonFieldType.NUMBER).description("요청한 현재 페이지"),
+                        PayloadDocumentation.fieldWithPath("data.totalPages")
+                            .type(JsonFieldType.NUMBER).description("총 페이지"),
+                        PayloadDocumentation.fieldWithPath("data.totalElements")
+                            .type(JsonFieldType.NUMBER).description("총 알림 개수"),
+                        PayloadDocumentation.fieldWithPath("data.numberOfElements")
+                            .type(JsonFieldType.NUMBER).description("현재 페이지의 알림 개수"),
+                        PayloadDocumentation.fieldWithPath("data.size")
+                            .type(JsonFieldType.NUMBER).description("한 페이지에 보여줄 알림 개수"),
+                    )
+                )
+            )
+    }
+
+    @Test
+    @Order(4)
+    fun `Read One Notification 200`() {
+        // given
+        val id = notificationRepository.save(
+            Notification(
+                content = "test content",
+                user = this.user,
+                link = "https://dev.csbroker.io"
+            )
+        ).id!!
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.put("$NOTIFICATION_ENDPOINT/read/{notification_id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "notifications/readOne",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.id")
+                            .type(JsonFieldType.NUMBER).description("알림 ID")
+                    )
+                )
+            )
+    }
+
+    @Test
+    @Order(5)
+    fun `Read Notifications 200`() {
+        // given
+        val ids = notificationRepository.saveAll(
+            (1..10).map {
+                Notification(
+                    content = "test content $it",
+                    user = this.user,
+                    link = "https://dev.csbroker.io"
+                )
+            }.toList()
+        ).map {
+            it.id!!
+        }.toList()
+
+        val notificationBulkReadDto = NotificationBulkReadDto(
+            ids = ids
+        )
+
+        val notificationBulkReadDtoString = objectMapper.writeValueAsString(notificationBulkReadDto)
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.put("$NOTIFICATION_ENDPOINT/read")
+                .content(notificationBulkReadDtoString)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "notifications/readBulk",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    PayloadDocumentation.requestFields(
+                        PayloadDocumentation.fieldWithPath("ids")
+                            .type(JsonFieldType.ARRAY).description("읽음 처리할 알림 ID 리스트")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status")
+                            .type(JsonFieldType.STRING).description("결과 상태"),
+                        PayloadDocumentation.fieldWithPath("data.size")
+                            .type(JsonFieldType.NUMBER).description("읽음 처리된 알림 개수")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
@@ -1,9 +1,12 @@
 package io.csbroker.apiserver.e2e
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.auth.ProviderType
+import io.csbroker.apiserver.common.enums.AssessmentType
 import io.csbroker.apiserver.common.enums.GradingStandardType
 import io.csbroker.apiserver.common.enums.Role
+import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 import io.csbroker.apiserver.dto.problem.grade.GradingResponseDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemAnswerDto
 import io.csbroker.apiserver.dto.problem.multiplechoiceproblem.MultipleChoiceProblemAnswerDto
@@ -22,9 +25,6 @@ import io.csbroker.apiserver.repository.ProblemRepository
 import io.csbroker.apiserver.repository.ProblemTagRepository
 import io.csbroker.apiserver.repository.TagRepository
 import io.csbroker.apiserver.repository.UserRepository
-import com.fasterxml.jackson.databind.ObjectMapper
-import io.csbroker.apiserver.common.enums.AssessmentType
-import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.hamcrest.CoreMatchers

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
@@ -1,5 +1,6 @@
 package io.csbroker.apiserver.e2e
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.csbroker.apiserver.auth.AuthTokenProvider
 import io.csbroker.apiserver.auth.ProviderType
 import io.csbroker.apiserver.common.enums.GradingStandardType
@@ -17,7 +18,6 @@ import io.csbroker.apiserver.repository.ProblemTagRepository
 import io.csbroker.apiserver.repository.TagRepository
 import io.csbroker.apiserver.repository.UserRepository
 import io.csbroker.apiserver.repository.common.RedisRepository
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Order


### PR DESCRIPTION
### Issue Number

close: N/A

### 작업 내역

알림 API를 설계하고 구현했습니다.

- [x] 알림 단건, 여러 건 생성, 조회, 단건 읽음 처리, 여러 건 읽음 처리, 읽지않은 알림 개수 조회 => 총 6개의 API를 구현했습니다.
- [x] API 구현에 따른 테스트 및 문서화를 진행했습니다.
- [x] 코드에서 linter warning이 발생하는 부분을 제거했습니다.

### 변경사항

- 의존성 목록
  -  N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [x] 문서 업데이트

### PR 특이 사항

- 알림 테이블은 "알림 아이디,  내용, 링크, 읽음 여부, 유저 아이디" 로 구성되어 있습니다.
- Admin에서 여러 유저 혹은 한 명의 유저에게 알림을 보낼 수 있게 Admin API를 구현하고, 알림을 프론트에서 가져오고 읽음 처리를 할 수 있도록 구현했습니다.

