### PR TITLE
MSTR-364 : 단답형 문제 답안 구성 언어 목록 필드 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -559,6 +559,36 @@ include::{snippets}/problems/grade/assessment/request-fields.adoc[]
 include::{snippets}/problems/grade/assessment/response-body.adoc[]
 include::{snippets}/problems/grade/assessment/response-fields.adoc[]
 
+
+=== Problems API V2 ( /api/v2/problems )
+==== 단답형 문제 단건 조회
+
+
+.description
+[source]
+----
+단답형 문제 단건 조회를 위한 API입니다.
+
+HTTP Method : GET
+End-Point   : /api/v2/problems/short/{problem_id:Long}
+----
+
+.Sample Request
+include::{snippets}/problems/v2/short/inquire/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/problems/v2/short/inquire/http-response.adoc[]
+
+.Path parameters
+include::{snippets}/problems/v2/short/inquire/path-parameters.adoc[]
+
+객관식 문제 단건 조회를 위한 path parameter의 설명입니다.
+
+
+.Response Body
+include::{snippets}/problems/v2/short/inquire/response-body.adoc[]
+include::{snippets}/problems/v2/short/inquire/response-fields.adoc[]
+
 === User API ( /api/v1/users )
 
 ==== 유저 조회

--- a/src/main/kotlin/io/csbroker/apiserver/common/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/security/SecurityConfig.kt
@@ -75,6 +75,7 @@ class SecurityConfig(
             )
             .permitAll()
             .antMatchers("/api/v1/**").permitAll()
+            .antMatchers("/api/v2/**").permitAll()
             .antMatchers("/actuator/**").permitAll()
             .antMatchers("/api/admin/**").hasAuthority(Role.ROLE_ADMIN.code)
             .anyRequest().authenticated()

--- a/src/main/kotlin/io/csbroker/apiserver/common/util/AuthUtil.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/util/AuthUtil.kt
@@ -1,0 +1,14 @@
+package io.csbroker.apiserver.common.util
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User
+
+fun getEmailFromSecurityContextHolder(): String? {
+    return try {
+        val principal = SecurityContextHolder.getContext().authentication.principal
+            as User
+        principal.username
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/AdminController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/AdminController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.enums.ErrorCode

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/AuthController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/AuthController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.config.properties.AppProperties

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/CommonController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/CommonController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.dto.StatsDto

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/CustomErrorController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/CustomErrorController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.web.servlet.error.ErrorController

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/NotificationController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/NotificationController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.dto.common.ApiResponse

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/ProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/ProblemController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.enums.ErrorCode

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/ProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/ProblemController.kt
@@ -3,6 +3,7 @@ package io.csbroker.apiserver.controller.v1
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.enums.ErrorCode
 import io.csbroker.apiserver.common.exception.UnAuthorizedException
+import io.csbroker.apiserver.common.util.getEmailFromSecurityContextHolder
 import io.csbroker.apiserver.dto.common.ApiResponse
 import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
@@ -19,7 +20,6 @@ import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemDetailResponse
 import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemGradingHistoryDto
 import io.csbroker.apiserver.service.ProblemService
 import org.springframework.data.domain.Pageable
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -46,7 +46,8 @@ class ProblemController(
         var solvedBy: String? = null
 
         if (isSolved != null) {
-            solvedBy = this.getEmail() ?: throw UnAuthorizedException(ErrorCode.FORBIDDEN, "사용자 권한이 없습니다.")
+            solvedBy = getEmailFromSecurityContextHolder()
+                ?: throw UnAuthorizedException(ErrorCode.FORBIDDEN, "사용자 권한이 없습니다.")
         }
 
         val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable)
@@ -57,21 +58,22 @@ class ProblemController(
 
     @GetMapping("/long/{id}")
     fun getLongProblemById(@PathVariable("id") id: Long): ApiResponse<LongProblemDetailResponseDto> {
-        val findProblemDetail = this.problemService.findLongProblemDetailById(id, this.getEmail())
+        val findProblemDetail = this.problemService.findLongProblemDetailById(id, getEmailFromSecurityContextHolder())
 
         return ApiResponse.success(findProblemDetail)
     }
 
     @GetMapping("/multiple/{id}")
     fun getMultipleProblemById(@PathVariable("id") id: Long): ApiResponse<MultipleChoiceProblemDetailResponseDto> {
-        val findProblemDetail = this.problemService.findMultipleChoiceProblemDetailById(id, this.getEmail())
+        val findProblemDetail =
+            this.problemService.findMultipleChoiceProblemDetailById(id, getEmailFromSecurityContextHolder())
 
         return ApiResponse.success(findProblemDetail)
     }
 
     @GetMapping("/short/{id}")
     fun getShortProblemById(@PathVariable("id") id: Long): ApiResponse<ShortProblemDetailResponseDto> {
-        val findProblemDetail = this.problemService.findShortProblemDetailById(id, this.getEmail())
+        val findProblemDetail = this.problemService.findShortProblemDetailById(id, getEmailFromSecurityContextHolder())
 
         return ApiResponse.success(findProblemDetail)
     }
@@ -121,15 +123,5 @@ class ProblemController(
                 )
             )
         )
-    }
-
-    private fun getEmail(): String? {
-        return try {
-            val principal = SecurityContextHolder.getContext().authentication.principal
-                as User
-            principal.username
-        } catch (e: Exception) {
-            null
-        }
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/UserController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/UserController.kt
@@ -1,4 +1,4 @@
-package io.csbroker.apiserver.controller
+package io.csbroker.apiserver.controller.v1
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.exception.EntityNotFoundException

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/ProblemControllerV2.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/ProblemControllerV2.kt
@@ -18,7 +18,8 @@ class ProblemControllerV2(
     @GetMapping("/short/{id}")
     fun getShortProblemById(@PathVariable("id") id: Long): ApiResponse<ShortProblemDetailResponseV2Dto> {
         val findProblemDetail = this.problemService.findShortProblemDetailByIdV2(
-            id, getEmailFromSecurityContextHolder()
+            id,
+            getEmailFromSecurityContextHolder()
         )
 
         return ApiResponse.success(findProblemDetail)

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/ProblemControllerV2.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/ProblemControllerV2.kt
@@ -1,0 +1,26 @@
+package io.csbroker.apiserver.controller.v2
+
+import io.csbroker.apiserver.common.util.getEmailFromSecurityContextHolder
+import io.csbroker.apiserver.controller.v2.response.ShortProblemDetailResponseV2Dto
+import io.csbroker.apiserver.dto.common.ApiResponse
+import io.csbroker.apiserver.service.ProblemService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v2/problems")
+class ProblemControllerV2(
+    private val problemService: ProblemService
+) {
+
+    @GetMapping("/short/{id}")
+    fun getShortProblemById(@PathVariable("id") id: Long): ApiResponse<ShortProblemDetailResponseV2Dto> {
+        val findProblemDetail = this.problemService.findShortProblemDetailByIdV2(
+            id, getEmailFromSecurityContextHolder()
+        )
+
+        return ApiResponse.success(findProblemDetail)
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/response/ShortProblemDetailResponseV2Dto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/response/ShortProblemDetailResponseV2Dto.kt
@@ -1,0 +1,20 @@
+package io.csbroker.apiserver.controller.v2.response
+
+class ShortProblemDetailResponseV2Dto(
+    val id: Long,
+    val title: String,
+    val tags: List<String>,
+    val description: String,
+    val correctSubmission: Int,
+    val correctUserCnt: Int,
+    val totalSubmission: Int,
+    val answerLength: Int,
+    val consistOf: ShortProblemAnswerType,
+    val isSolved: Boolean
+)
+
+enum class ShortProblemAnswerType {
+    ENGLISH,
+    KOREAN,
+    NUMERIC
+}

--- a/src/main/kotlin/io/csbroker/apiserver/model/ShortProblem.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/ShortProblem.kt
@@ -1,5 +1,7 @@
 package io.csbroker.apiserver.model
 
+import io.csbroker.apiserver.common.enums.ErrorCode
+import io.csbroker.apiserver.common.exception.InternalServiceException
 import io.csbroker.apiserver.controller.v2.response.ShortProblemAnswerType
 import io.csbroker.apiserver.controller.v2.response.ShortProblemDetailResponseV2Dto
 import io.csbroker.apiserver.dto.problem.ProblemCommonDetailResponse
@@ -97,18 +99,26 @@ class ShortProblem(
     }
 
     private fun getTypeOfAnswer(): ShortProblemAnswerType {
-        return if (this.isEnglish()) {
-            ShortProblemAnswerType.ENGLISH
-        } else if (this.isNumeric()) {
-            ShortProblemAnswerType.NUMERIC
-        } else {
-            ShortProblemAnswerType.KOREAN
+        return when {
+            this.isEnglish() -> ShortProblemAnswerType.ENGLISH
+            this.isKorean() -> ShortProblemAnswerType.KOREAN
+            this.isNumeric() -> ShortProblemAnswerType.NUMERIC
+            else -> throw InternalServiceException(ErrorCode.SERVER_ERROR, "문제 답변이 영어, 한글, 숫자가 아닙니다.")
         }
+    }
+
+    private fun isKorean(): Boolean {
+        for (c in this.answer.replace("\\s".toRegex(), "")) {
+            if (c !in 'ㄱ'..'ㅣ' && c !in '가'..'힣') {
+                return false
+            }
+        }
+        return true
     }
 
     private fun isEnglish(): Boolean {
         for (c in this.answer.replace("\\s".toRegex(), "")) {
-            if (c !in 'A'..'Z' && c !in 'a'..'z' && c !in '0'..'9') {
+            if (c !in 'A'..'Z' && c !in 'a'..'z') {
                 return false
             }
         }

--- a/src/main/kotlin/io/csbroker/apiserver/model/ShortProblem.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/ShortProblem.kt
@@ -1,5 +1,7 @@
 package io.csbroker.apiserver.model
 
+import io.csbroker.apiserver.controller.v2.response.ShortProblemAnswerType
+import io.csbroker.apiserver.controller.v2.response.ShortProblemDetailResponseV2Dto
 import io.csbroker.apiserver.dto.problem.ProblemCommonDetailResponse
 import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemDetailResponseDto
 import io.csbroker.apiserver.dto.problem.shortproblem.ShortProblemResponseDto
@@ -77,9 +79,45 @@ class ShortProblem(
         )
     }
 
+    fun toDetailResponseV2Dto(email: String?): ShortProblemDetailResponseV2Dto {
+        val commonDetail = ProblemCommonDetailResponse.getCommonDetail(this)
+
+        return ShortProblemDetailResponseV2Dto(
+            this.id!!,
+            this.title,
+            commonDetail.tags,
+            this.description,
+            commonDetail.correctSubmission,
+            commonDetail.correctUserCnt,
+            commonDetail.totalSubmission,
+            this.answer.length,
+            this.getTypeOfAnswer(),
+            this.gradingHistory.any { it.user.email == email }
+        )
+    }
+
+    private fun getTypeOfAnswer(): ShortProblemAnswerType {
+        return if (this.isEnglish()) {
+            ShortProblemAnswerType.ENGLISH
+        } else if (this.isNumeric()) {
+            ShortProblemAnswerType.NUMERIC
+        } else {
+            ShortProblemAnswerType.KOREAN
+        }
+    }
+
     private fun isEnglish(): Boolean {
         for (c in this.answer.replace("\\s".toRegex(), "")) {
             if (c !in 'A'..'Z' && c !in 'a'..'z' && c !in '0'..'9') {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun isNumeric(): Boolean {
+        for (c in this.answer.replace("\\s".toRegex(), "")) {
+            if (c !in '0'..'9') {
                 return false
             }
         }

--- a/src/main/kotlin/io/csbroker/apiserver/service/ProblemService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/ProblemService.kt
@@ -1,5 +1,6 @@
 package io.csbroker.apiserver.service
 
+import io.csbroker.apiserver.controller.v2.response.ShortProblemDetailResponseV2Dto
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
@@ -45,6 +46,7 @@ interface ProblemService {
 
     fun findLongProblemDetailById(id: Long, email: String?): LongProblemDetailResponseDto
     fun findShortProblemDetailById(id: Long, email: String?): ShortProblemDetailResponseDto
+    fun findShortProblemDetailByIdV2(id: Long, email: String?): ShortProblemDetailResponseV2Dto
     fun findMultipleChoiceProblemDetailById(id: Long, email: String?): MultipleChoiceProblemDetailResponseDto
     fun findLongProblemById(id: Long): LongProblemResponseDto
     fun findShortProblemById(id: Long): ShortProblemResponseDto

--- a/src/main/kotlin/io/csbroker/apiserver/service/ProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/ProblemServiceImpl.kt
@@ -9,6 +9,7 @@ import io.csbroker.apiserver.common.exception.EntityNotFoundException
 import io.csbroker.apiserver.common.exception.InternalServiceException
 import io.csbroker.apiserver.common.exception.UnAuthorizedException
 import io.csbroker.apiserver.common.util.log
+import io.csbroker.apiserver.controller.v2.response.ShortProblemDetailResponseV2Dto
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
@@ -131,6 +132,11 @@ class ProblemServiceImpl(
 
     override fun findShortProblemDetailById(id: Long, email: String?): ShortProblemDetailResponseDto {
         return shortProblemRepository.findByIdOrNull(id)?.toDetailResponseDto(email)
+            ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
+    }
+
+    override fun findShortProblemDetailByIdV2(id: Long, email: String?): ShortProblemDetailResponseV2Dto {
+        return shortProblemRepository.findByIdOrNull(id)?.toDetailResponseV2Dto(email)
             ?: throw EntityNotFoundException("${id}번 문제를 찾을 수 없습니다.")
     }
 

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemControllerV2Test.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemControllerV2Test.kt
@@ -1,0 +1,123 @@
+package io.csbroker.apiserver.e2e
+
+import io.csbroker.apiserver.auth.ProviderType
+import io.csbroker.apiserver.model.ShortProblem
+import io.csbroker.apiserver.model.User
+import io.csbroker.apiserver.repository.ProblemRepository
+import io.csbroker.apiserver.repository.UserRepository
+import org.hamcrest.CoreMatchers
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+class ProblemControllerV2Test {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var problemRepository: ProblemRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    private val PROBLEM_ENDPOINT = "/api/v2/problems"
+
+    private var adminUser: User? = null
+
+    @BeforeAll
+    fun setUpData() {
+        val user = User(
+            email = "test2@test.com",
+            username = "test2",
+            providerType = ProviderType.LOCAL
+        )
+
+        userRepository.save(user)
+
+        adminUser = user
+    }
+
+    @Test
+    @Order(1)
+    fun `Short problem 단건 조회`() {
+        // given
+        val shortProblem = ShortProblem(
+            title = "test11",
+            description = "test",
+            creator = adminUser!!,
+            answer = "test",
+            score = 5.0
+        )
+
+        problemRepository.save(shortProblem)
+
+        val urlString = "$PROBLEM_ENDPOINT/short/{problem_id}"
+
+        // when
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(urlString, shortProblem.id)
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().string(CoreMatchers.containsString("success")))
+            .andDo(
+                document(
+                    "problems/v2/short/inquire",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("problem_id").description("문제 id")
+                    ),
+                    responseFields(
+                        fieldWithPath("status").type(JsonFieldType.STRING).description("결과 상태"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("문제 id"),
+                        fieldWithPath("data.title").type(JsonFieldType.STRING)
+                            .description("문제 제목"),
+                        fieldWithPath("data.description").type(JsonFieldType.STRING)
+                            .description("문제 설명"),
+                        fieldWithPath("data.tags").type(JsonFieldType.ARRAY).description("태그"),
+                        fieldWithPath("data.correctUserCnt").type(JsonFieldType.NUMBER)
+                            .description("맞은 사람 수"),
+                        fieldWithPath("data.correctSubmission").type(JsonFieldType.NUMBER)
+                            .description("맞은 제출 수"),
+                        fieldWithPath("data.totalSubmission").type(JsonFieldType.NUMBER)
+                            .description("총 제출 수"),
+                        fieldWithPath("data.answerLength").type(JsonFieldType.NUMBER)
+                            .description("정답 글자수 ( 힌트 )"),
+                        fieldWithPath("data.consistOf").type(JsonFieldType.STRING)
+                            .description("정답 언어 ( 영어면 ENGLISH, 한국어면 KOREAN, 숫자면 NUMERIC )"),
+                        fieldWithPath("data.isSolved").type(JsonFieldType.BOOLEAN)
+                            .description("푼 문제 여부")
+                    )
+                )
+            )
+    }
+}

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemControllerV2Test.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemControllerV2Test.kt
@@ -53,8 +53,8 @@ class ProblemControllerV2Test {
     @BeforeAll
     fun setUpData() {
         val user = User(
-            email = "test2@test.com",
-            username = "test2",
+            email = "test50@test.com",
+            username = "test50",
             providerType = ProviderType.LOCAL
         )
 


### PR DESCRIPTION
### Issue Number

close: MSTR-364

### 작업 내역

- [x] 단답형 문제에서 영어, 한글, 숫자로 구성된 답안인지 구별하는 필드를 추가하였습니다.
- [x] 위 작업에 따라, 테스트 및 문서를 수정했습니다.
- [x] 이메일 정보를 jwt에서 가져오는 로직을 공통 유틸로 리팩토링했습니다.
- [x] 이전 버전과 호환성을 유지하기 위해, **v2 controller**를 만들어 작업하였습니다.  

### 변경사항

- 의존성 목록

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 이전 controller를 v1으로 옮기면서 file change 수가 조금 늘어나 보일 수 있습니다.
- @Kim-Hyunjo v2 controller를 추가했기에, 이 부분을 잘 보고 수정하시길 바랍니다

