### PR TITLE
fix : 문제 풀이 여부 필터가 작동하지 않던 버그 수정

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
@@ -109,7 +109,8 @@ class ProblemRepositoryCustomImpl(
         val solvedProblemIds = queryFactory.select(gradingHistory.problem.id)
             .from(gradingHistory)
             .innerJoin(gradingHistory.user, user)
-            .where(gradingHistory.user.email.eq(email))
+            .innerJoin(gradingHistory.problem, problem)
+            .where(gradingHistory.user.email.eq(email), gradingHistory.score.eq(problem.score))
 
         return if (isSolved) problem.id.`in`(solvedProblemIds) else problem.id.notIn(solvedProblemIds)
     }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/ProblemRepositoryCustomImpl.kt
@@ -106,6 +106,11 @@ class ProblemRepositoryCustomImpl(
             return null
         }
 
-        return if (isSolved) user.email.eq(email) else user.email.ne(email)
+        val solvedProblemIds = queryFactory.select(gradingHistory.problem.id)
+            .from(gradingHistory)
+            .innerJoin(gradingHistory.user, user)
+            .where(gradingHistory.user.email.eq(email))
+
+        return if (isSolved) problem.id.`in`(solvedProblemIds) else problem.id.notIn(solvedProblemIds)
     }
 }


### PR DESCRIPTION
### Issue Number

close: N/A

### 작업 내역

- [x] 문제 풀이 여부 필터가 작동하지 않던 버그를 *드디어* 수정했습니다.

### 변경사항

- 의존성 목록 N/A

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항
- 원래 grading_history의 user 기록이 있나 없나로 찾고 있던 것이 잘못된 로직이였다는 것을 깨닫고, 서브쿼리로 해결했습니다.
  - 아직도 SQL은 너무 어려워서 join으로 해결할 수 있을 것 같지만 방법을 못찾아 일단 sub query로 해결해봅니다.

