### PR TITLE
[MSTR-374] 비밀번호 변경시 이전 비밀번호를 확인하도록 수정

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/common/filter/LoggingFilter.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/filter/LoggingFilter.kt
@@ -73,17 +73,25 @@ class LoggingFilter : OncePerRequestFilter() {
         if (visible) {
             val content: ByteArray = StreamUtils.copyToByteArray(inputStream)
             if (content.isNotEmpty()) {
-                var contentString = String(content)
-
-                if (contentString.contains("password")) {
-                    contentString = contentString.replace("\"password\":\".*\"".toRegex(), "\"password\":\"*****\"")
-                }
-
-                log.info("{} Payload: {}", prefix, contentString)
+                log.info("{} Payload: {}", prefix, getPayload(content))
             }
         } else {
             log.info("{} Payload: Binary Content", prefix)
         }
+    }
+
+    private fun getPayload(content: ByteArray): String {
+        val contentString = String(content)
+
+        if (contentString.contains("originalPassword")) {
+            return contentString.replace("\"originalPassword\":\".*\"".toRegex(), "\"originalPassword\":\"*****\"")
+        }
+
+        if (contentString.contains("password")) {
+            return contentString.replace("\"password\":\".*\"".toRegex(), "\"password\":\"*****\"")
+        }
+
+        return contentString
     }
 
     private fun isVisible(mediaType: MediaType): Boolean {

--- a/src/main/kotlin/io/csbroker/apiserver/dto/user/UserResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/user/UserResponseDto.kt
@@ -16,5 +16,5 @@ data class UserResponseDto(
     val profileImgUrl: String?,
     var githubUrl: String?,
     var linkedinUrl: String?,
-    val providerType: ProviderType
+    val providerType: ProviderType,
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/user/UserResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/user/UserResponseDto.kt
@@ -1,5 +1,6 @@
 package io.csbroker.apiserver.dto.user
 
+import io.csbroker.apiserver.auth.ProviderType
 import io.csbroker.apiserver.common.enums.Role
 import java.util.UUID
 
@@ -14,5 +15,6 @@ data class UserResponseDto(
     val techs: List<String>,
     val profileImgUrl: String?,
     var githubUrl: String?,
-    var linkedinUrl: String?
+    var linkedinUrl: String?,
+    val providerType: ProviderType
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/user/UserUpdateRequestDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/user/UserUpdateRequestDto.kt
@@ -3,6 +3,7 @@ package io.csbroker.apiserver.dto.user
 data class UserUpdateRequestDto(
     val profileImageUrl: String?,
     val username: String?,
+    val originalPassword: String?,
     var password: String?,
     var major: String? = null,
     var job: String? = null,

--- a/src/main/kotlin/io/csbroker/apiserver/model/User.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/User.kt
@@ -83,7 +83,7 @@ class User(
     val gradingHistories: MutableList<GradingHistory> = mutableListOf(),
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
-    val notifications: MutableList<Notification> = mutableListOf()
+    val notifications: MutableList<Notification> = mutableListOf(),
 ) : BaseEntity() {
     fun updateInfo(userUpdateRequestDto: UserUpdateRequestDto) {
         profileImageUrl = userUpdateRequestDto.profileImageUrl ?: profileImageUrl
@@ -110,7 +110,7 @@ class User(
             profileImgUrl = profileImageUrl,
             githubUrl = githubUrl,
             linkedinUrl = linkedinUrl,
-            providerType = providerType
+            providerType = providerType,
         )
     }
 

--- a/src/main/kotlin/io/csbroker/apiserver/model/User.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/User.kt
@@ -110,6 +110,7 @@ class User(
             profileImgUrl = profileImageUrl,
             githubUrl = githubUrl,
             linkedinUrl = linkedinUrl,
+            providerType = providerType
         )
     }
 

--- a/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.csbroker.apiserver.service
 
+import io.csbroker.apiserver.auth.ProviderType
 import io.csbroker.apiserver.common.enums.ErrorCode
 import io.csbroker.apiserver.common.enums.Role
 import io.csbroker.apiserver.common.exception.EntityNotFoundException
@@ -38,6 +39,11 @@ class UserServiceImpl(
             ?: throw EntityNotFoundException("${uuid}를 가진 유저를 찾을 수 없습니다.")
 
         userUpdateRequestDto.password?.let {
+            if (findUser.providerType == ProviderType.LOCAL &&
+                !bCryptPasswordEncoder.matches(userUpdateRequestDto.password, findUser.password)
+            ) {
+                throw UnAuthorizedException(ErrorCode.PASSWORD_MISS_MATCH, "비밀번호가 일치하지 않습니다!")
+            }
             val encodedPassword = bCryptPasswordEncoder.encode(userUpdateRequestDto.password)
             userUpdateRequestDto.password = encodedPassword
         }

--- a/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/UserServiceImpl.kt
@@ -40,7 +40,7 @@ class UserServiceImpl(
 
         userUpdateRequestDto.password?.let {
             if (findUser.providerType == ProviderType.LOCAL &&
-                !bCryptPasswordEncoder.matches(userUpdateRequestDto.password, findUser.password)
+                !bCryptPasswordEncoder.matches(userUpdateRequestDto.originalPassword, findUser.password)
             ) {
                 throw UnAuthorizedException(ErrorCode.PASSWORD_MISS_MATCH, "비밀번호가 일치하지 않습니다!")
             }

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/ProblemApiControllerTest.kt
@@ -379,7 +379,7 @@ class ProblemApiControllerTest {
     fun `problem 검색`() {
         // given
         val query = "test"
-        val isSolved = true
+        val isSolved = false
         val tags = "os,ds"
         val page = 0
         val size = 10

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
@@ -42,6 +42,7 @@ import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -58,6 +59,9 @@ import java.util.UUID
 class UserControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var bcryptPasswordEncoder: BCryptPasswordEncoder
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -107,7 +111,8 @@ class UserControllerTest {
             job = "백엔드 개발자",
             tech = "Spring, Docker, Kotlin",
             githubUrl = "https://github.com/kshired",
-            linkedinUrl = "https://www.linkedin.com/in/seongil-kim-40773b23b/"
+            linkedinUrl = "https://www.linkedin.com/in/seongil-kim-40773b23b/",
+            password = bcryptPasswordEncoder.encode("password")
         )
 
         userRepository.save(admin)

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
@@ -243,7 +243,9 @@ class UserControllerTest {
                         fieldWithPath("data.githubUrl")
                             .type(JsonFieldType.STRING).description("Github url").optional(),
                         fieldWithPath("data.linkedinUrl")
-                            .type(JsonFieldType.STRING).description("LinkedIn url").optional()
+                            .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
+                        fieldWithPath("data.providerType")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
                     )
                 )
             )
@@ -297,7 +299,9 @@ class UserControllerTest {
                         fieldWithPath("data.[].githubUrl")
                             .type(JsonFieldType.STRING).description("Github url").optional(),
                         fieldWithPath("data.[].linkedinUrl")
-                            .type(JsonFieldType.STRING).description("LinkedIn url").optional()
+                            .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
+                        fieldWithPath("data.[].providerType")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
                     )
                 )
             )
@@ -323,7 +327,8 @@ class UserControllerTest {
             jobObjective = "프론트엔드 개발자",
             techs = listOf("react", "typescript"),
             githubUrl = "https://github.com/Kim-Hyunjo",
-            linkedinUrl = "https://www.linkedin.com/in/%EC%9E%AC%EC%9B%90-%EB%AF%BC-2b5149211"
+            linkedinUrl = "https://www.linkedin.com/in/%EC%9E%AC%EC%9B%90-%EB%AF%BC-2b5149211",
+            originalPassword = "password"
         )
 
         val userUpdateRequestDtoString = objectMapper.writeValueAsString(userUpdateRequestDto)
@@ -354,6 +359,8 @@ class UserControllerTest {
                             .description("수정할 닉네임 ( 필수 X )").optional(),
                         fieldWithPath("profileImageUrl").type(JsonFieldType.STRING)
                             .description("수정할 프로필 이미지 url ( 필수 X )").optional(),
+                        fieldWithPath("originalPassword").type(JsonFieldType.STRING)
+                            .description("수정전 비밀번호 ( 필수 X, but 수정시 필수 )").optional(),
                         fieldWithPath("password").type(JsonFieldType.STRING)
                             .description("수정할 비밀번호 ( 필수 X )").optional(),
                         fieldWithPath("major").type(JsonFieldType.STRING)
@@ -388,7 +395,9 @@ class UserControllerTest {
                         fieldWithPath("data.githubUrl")
                             .type(JsonFieldType.STRING).description("Github url").optional(),
                         fieldWithPath("data.linkedinUrl")
-                            .type(JsonFieldType.STRING).description("LinkedIn url").optional()
+                            .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
+                        fieldWithPath("data.providerType")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
                     )
                 )
             )

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/UserControllerTest.kt
@@ -112,7 +112,7 @@ class UserControllerTest {
             tech = "Spring, Docker, Kotlin",
             githubUrl = "https://github.com/kshired",
             linkedinUrl = "https://www.linkedin.com/in/seongil-kim-40773b23b/",
-            password = bcryptPasswordEncoder.encode("password")
+            password = bcryptPasswordEncoder.encode("password"),
         )
 
         userRepository.save(admin)
@@ -250,7 +250,7 @@ class UserControllerTest {
                         fieldWithPath("data.linkedinUrl")
                             .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
                         fieldWithPath("data.providerType")
-                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )"),
                     )
                 )
             )
@@ -306,7 +306,7 @@ class UserControllerTest {
                         fieldWithPath("data.[].linkedinUrl")
                             .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
                         fieldWithPath("data.[].providerType")
-                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )"),
                     )
                 )
             )
@@ -333,7 +333,7 @@ class UserControllerTest {
             techs = listOf("react", "typescript"),
             githubUrl = "https://github.com/Kim-Hyunjo",
             linkedinUrl = "https://www.linkedin.com/in/%EC%9E%AC%EC%9B%90-%EB%AF%BC-2b5149211",
-            originalPassword = "password"
+            originalPassword = "password",
         )
 
         val userUpdateRequestDtoString = objectMapper.writeValueAsString(userUpdateRequestDto)
@@ -402,7 +402,7 @@ class UserControllerTest {
                         fieldWithPath("data.linkedinUrl")
                             .type(JsonFieldType.STRING).description("LinkedIn url").optional(),
                         fieldWithPath("data.providerType")
-                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )")
+                            .type(JsonFieldType.STRING).description("Provider Type ( GOOGLE, GITHUB, LOCAL )"),
                     )
                 )
             )

--- a/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
@@ -135,7 +135,7 @@ class UserServiceTest {
         val exception = assertThrows<EntityNotFoundException> {
             userService.modifyUser(
                 id,
-                UserUpdateRequestDto("test-url.com", "test", "test1234!")
+                UserUpdateRequestDto("test-url.com", "test", "test1234!", "test1234")
             )
         }
 
@@ -148,7 +148,7 @@ class UserServiceTest {
     fun `유저 수정 성공 without password 테스트`() {
         // given
         val id = user.id!!
-        val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", null)
+        val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", null, null)
         every { userRepository.findByIdOrNull(id) } returns user
 
         // when
@@ -168,7 +168,7 @@ class UserServiceTest {
     fun `유저 수정 성공 with password 테스트`() {
         // given
         val id = user.id!!
-        val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", "test123!")
+        val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", "test1234!", "test123!")
         every { userRepository.findByIdOrNull(id) } returns user
         every { passwordEncoder.encode("test123!") } returns "some-encrypted-password"
 

--- a/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
@@ -171,6 +171,7 @@ class UserServiceTest {
         val userUpdateRequestDto = UserUpdateRequestDto("test-url.com", "test", "test1234!", "test123!")
         every { userRepository.findByIdOrNull(id) } returns user
         every { passwordEncoder.encode("test123!") } returns "some-encrypted-password"
+        every { passwordEncoder.matches(any(), any()) } returns true
 
         // when
         val modifyUser = userService.modifyUser(

--- a/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/unit/service/UserServiceTest.kt
@@ -135,7 +135,12 @@ class UserServiceTest {
         val exception = assertThrows<EntityNotFoundException> {
             userService.modifyUser(
                 id,
-                UserUpdateRequestDto("test-url.com", "test", "test1234!", "test1234")
+                UserUpdateRequestDto(
+                    "test-url.com",
+                    "test",
+                    "test1234!",
+                    "test1234",
+                ),
             )
         }
 


### PR DESCRIPTION
### Issue Number

close: #MSTR-374

### 작업 내역

- [x] 비밀번호 변경시 이전 비밀번호를 확인하도록 수정
- [x] 직접 회원가입한 사람만 비밀번호를 변경할 수 있도록 하기 위해, 회원가입한 사람의 ProviderType을 응답으로 주도록 응답값 추가
- [x] 비밀번호의 raw값을 로그에 남기지 않도록 로깅필터 수정

### 변경사항

- 의존성 목록 N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- N/A

