### PR TITLE
feat : rate-limiter 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
     implementation("aws.sdk.kotlin:ses:0.16.0")
     implementation("aws.sdk.kotlin:s3:0.16.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+
+    // rate-limiter
+    implementation("com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.2.0")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/io/csbroker/apiserver/common/config/security/WebMcvConfig.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/config/security/WebMcvConfig.kt
@@ -1,15 +1,38 @@
 package io.csbroker.apiserver.common.config.security
 
 import io.csbroker.apiserver.auth.LoginUserArgumentResolver
+import io.csbroker.apiserver.common.interceptor.HttpInterceptor
+import io.csbroker.apiserver.common.interceptor.ratelimit.IpBasedRateLimiter
+import io.csbroker.apiserver.common.interceptor.ratelimit.RateLimiter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebMcvConfig(
+    @Value("\${server.rate-limit}")
+    private val rateLimit: Long,
     private val loginUserArgumentResolver: LoginUserArgumentResolver,
 ) : WebMvcConfigurer {
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(loginUserArgumentResolver)
+    }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(httpInterceptor())
+    }
+
+    @Bean
+    fun ipBasedRateLimiter(): RateLimiter {
+        return IpBasedRateLimiter(rateLimit)
+    }
+
+    @Bean
+    fun httpInterceptor(): HandlerInterceptor {
+        return HttpInterceptor(ipBasedRateLimiter())
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/common/interceptor/HttpInterceptor.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/interceptor/HttpInterceptor.kt
@@ -2,10 +2,10 @@ package io.csbroker.apiserver.common.interceptor
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.csbroker.apiserver.common.interceptor.ratelimit.RateLimiter
+import io.csbroker.apiserver.common.util.setJsonResponseBody
+import io.csbroker.apiserver.common.util.setStatus
 import io.csbroker.apiserver.dto.common.ApiResponse
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.web.servlet.HandlerInterceptor
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -18,17 +18,16 @@ class HttpInterceptor(
             return true
         }
 
-        setBodyTooManyRequest(response)
+        response.setTooManyRequest()
         return false
     }
 
-    private fun setBodyTooManyRequest(response: HttpServletResponse) {
-        val errorResponse = ObjectMapper().writeValueAsBytes(
-            ApiResponse.fail("짧은 시간 동안 너무 많이 요청하였습니다."),
+    private fun HttpServletResponse.setTooManyRequest() {
+        this.setStatus(HttpStatus.TOO_MANY_REQUESTS)
+        this.setJsonResponseBody(
+            ObjectMapper().writeValueAsBytes(
+                ApiResponse.fail("짧은 시간 동안 너무 많이 요청하였습니다."),
+            ),
         )
-        response.setContentLength(errorResponse.size)
-        response.outputStream.write(errorResponse)
-        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        response.status = HttpStatus.TOO_MANY_REQUESTS.value()
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/common/interceptor/HttpInterceptor.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/interceptor/HttpInterceptor.kt
@@ -1,0 +1,34 @@
+package io.csbroker.apiserver.common.interceptor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.csbroker.apiserver.common.interceptor.ratelimit.RateLimiter
+import io.csbroker.apiserver.dto.common.ApiResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class HttpInterceptor(
+    private val rateLimiter: RateLimiter,
+) : HandlerInterceptor {
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (rateLimiter.resolveRate(request.remoteAddr)) {
+            return true
+        }
+
+        setBodyTooManyRequest(response)
+        return false
+    }
+
+    private fun setBodyTooManyRequest(response: HttpServletResponse) {
+        val errorResponse = ObjectMapper().writeValueAsBytes(
+            ApiResponse.fail("짧은 시간 동안 너무 많이 요청하였습니다."),
+        )
+        response.setContentLength(errorResponse.size)
+        response.outputStream.write(errorResponse)
+        response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/BaseRateLimiter.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/BaseRateLimiter.kt
@@ -1,0 +1,13 @@
+package io.csbroker.apiserver.common.interceptor.ratelimit
+
+import io.github.bucket4j.Bucket
+
+abstract class BaseRateLimiter(
+    private val bucketCache: MutableMap<String, Bucket>,
+) : RateLimiter {
+    protected fun resolveRate(key: String, consumeCnt: Long, createNewBucket: () -> Bucket): Boolean {
+        return bucketCache.computeIfAbsent(key) {
+            createNewBucket()
+        }.tryConsume(consumeCnt)
+    }
+}

--- a/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/IpBasedRateLimiter.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/IpBasedRateLimiter.kt
@@ -1,0 +1,29 @@
+package io.csbroker.apiserver.common.interceptor.ratelimit
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Bucket4j
+import io.github.bucket4j.Refill
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+class IpBasedRateLimiter(
+    private val rateLimit: Long,
+) : BaseRateLimiter(
+    ConcurrentHashMap<String, Bucket>(),
+) {
+    override fun resolveRate(key: String): Boolean {
+        return super.resolveRate(key, key.getConsumeCountByIp()) {
+            createNewBucket()
+        }
+    }
+
+    private fun String.getConsumeCountByIp(): Long {
+        // TODO : 특정 ip 대역에 따라 무제한 허용 or 무제한 접근 금지
+        return 1
+    }
+
+    private fun createNewBucket() = Bucket4j.builder()
+        .addLimit(Bandwidth.classic(rateLimit, Refill.intervally(rateLimit, Duration.ofSeconds(1))))
+        .build()
+}

--- a/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/RateLimiter.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/interceptor/ratelimit/RateLimiter.kt
@@ -1,0 +1,5 @@
+package io.csbroker.apiserver.common.interceptor.ratelimit
+
+interface RateLimiter {
+    fun resolveRate(key: String): Boolean
+}

--- a/src/main/kotlin/io/csbroker/apiserver/common/util/ResponseUtil.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/common/util/ResponseUtil.kt
@@ -1,0 +1,16 @@
+package io.csbroker.apiserver.common.util
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import javax.servlet.http.HttpServletResponse
+
+fun HttpServletResponse.setStatus(status: HttpStatus) {
+    this.status = status.value()
+}
+
+fun HttpServletResponse.setJsonResponseBody(responseBody: ByteArray) {
+    this.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+    this.setContentLength(responseBody.size)
+    this.outputStream.write(responseBody)
+}


### PR DESCRIPTION
### Issue Number

close: N/A

### 작업 내역

- [x] rate-limiter 추가

### 변경사항

- N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

- 1초 내 10번이상의 요청이 반복적으로 나가는 경우 어뷰징으로 간주하여, rate-limit을 걸었습니다.
  -  application 단위의 rate-limit이기 때문에.. 요청은 받지만, db에 부하를 주는 것을 방지할 수 있음.