### PR TITLE
feat : 서술형 모범 답안을 여러개로 저장할 수 있도록 어드민 API 수정

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemResponseDto.kt
@@ -6,7 +6,7 @@ data class LongProblemResponseDto(
     val id: Long,
     val title: String,
     val description: String,
-    val standardAnswer: String,
+    val standardAnswers: List<String>,
     val tags: List<String>,
     val gradingStandards: List<GradingStandardResponseDto>,
     val isActive: Boolean,

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemUpsertRequestDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/longproblem/LongProblemUpsertRequestDto.kt
@@ -8,7 +8,7 @@ import io.csbroker.apiserver.model.User
 data class LongProblemUpsertRequestDto(
     val title: String,
     val description: String,
-    val standardAnswer: String,
+    val standardAnswers: List<String>,
     val tags: MutableList<String>,
     val gradingStandards: MutableList<GradingStandardData>,
     val isGradable: Boolean = false,
@@ -25,7 +25,7 @@ data class LongProblemUpsertRequestDto(
         return LongProblem(
             title = title,
             description = description,
-            standardAnswer = standardAnswer,
+            standardAnswer = "",
             creator = creator,
         )
     }

--- a/src/main/kotlin/io/csbroker/apiserver/model/LongProblem.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/LongProblem.kt
@@ -28,6 +28,9 @@ class LongProblem(
 
     @OneToMany(mappedBy = "problem", cascade = [CascadeType.ALL])
     var userAnswers: MutableList<UserAnswer> = mutableListOf(),
+
+    @OneToMany(mappedBy = "longProblem", cascade = [CascadeType.ALL])
+    var standardAnswers: MutableList<StandardAnswer> = mutableListOf(),
 ) : Problem(
     title = title,
     description = description,
@@ -44,7 +47,7 @@ class LongProblem(
     fun updateFromDto(upsertRequestDto: LongProblemUpsertRequestDto) {
         title = upsertRequestDto.title
         description = upsertRequestDto.description
-        standardAnswer = upsertRequestDto.standardAnswer
+        standardAnswer = upsertRequestDto.standardAnswers.first()
         isGradable = upsertRequestDto.isGradable
         isActive = upsertRequestDto.isActive
     }
@@ -54,7 +57,7 @@ class LongProblem(
             id!!,
             title,
             description,
-            standardAnswer,
+            standardAnswers.map { it.content },
             problemTags.map { it.tag.name },
             gradingStandards.map { GradingStandardResponseDto.fromGradingStandard(it) },
             isActive,

--- a/src/main/kotlin/io/csbroker/apiserver/repository/StandardAnswerRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/StandardAnswerRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface StandardAnswerRepository : JpaRepository<StandardAnswer, Long> {
     fun findAllByLongProblem(longProblem: LongProblem): List<StandardAnswer>
+    fun deleteAllByLongProblem(longProblem: LongProblem)
 }

--- a/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/e2e/AdminControllerTest.kt
@@ -139,10 +139,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db", "network"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -197,7 +194,7 @@ class AdminControllerTest {
                             .description("문제 제목"),
                         PayloadDocumentation.fieldWithPath("description").type(JsonFieldType.STRING)
                             .description("문제 설명"),
-                        PayloadDocumentation.fieldWithPath("standardAnswer").type(JsonFieldType.STRING)
+                        PayloadDocumentation.fieldWithPath("standardAnswers").type(JsonFieldType.ARRAY)
                             .description("모범 답안"),
                         PayloadDocumentation.fieldWithPath("tags").type(JsonFieldType.ARRAY)
                             .description("태그"),
@@ -239,10 +236,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -286,10 +280,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -350,7 +341,7 @@ class AdminControllerTest {
                             .description("문제 제목"),
                         PayloadDocumentation.fieldWithPath("description").type(JsonFieldType.STRING)
                             .description("문제 설명"),
-                        PayloadDocumentation.fieldWithPath("standardAnswer").type(JsonFieldType.STRING)
+                        PayloadDocumentation.fieldWithPath("standardAnswers").type(JsonFieldType.ARRAY)
                             .description("모범 답안"),
                         PayloadDocumentation.fieldWithPath("tags").type(JsonFieldType.ARRAY)
                             .description("태그"),
@@ -392,10 +383,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -456,7 +444,7 @@ class AdminControllerTest {
                             .description("문제 제목"),
                         PayloadDocumentation.fieldWithPath("data.description").type(JsonFieldType.STRING)
                             .description("문제 설명"),
-                        PayloadDocumentation.fieldWithPath("data.standardAnswer").type(JsonFieldType.STRING)
+                        PayloadDocumentation.fieldWithPath("data.standardAnswers").type(JsonFieldType.ARRAY)
                             .description("모범 답안"),
                         PayloadDocumentation.fieldWithPath("data.tags").type(JsonFieldType.ARRAY)
                             .description("태그"),
@@ -1013,10 +1001,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -1110,10 +1095,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -1218,10 +1200,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -1341,10 +1320,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -1449,10 +1425,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -1560,10 +1533,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
                 """.trimIndent(),
-                """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-                """.trimIndent(),
+                listOf("ab", "bc"),
                 mutableListOf("db"),
                 mutableListOf(
                     LongProblemUpsertRequestDto.GradingStandardData(
@@ -1856,10 +1826,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -2042,10 +2009,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -2143,10 +2107,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(
@@ -2243,10 +2204,7 @@ class AdminControllerTest {
                 Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software
                 like Aldus PageMaker including versions of Lorem Ipsum.
             """.trimIndent(),
-            """
-                It is a long established fact that a reader will be distracted by the readable content of
-                a page when looking at its layout.
-            """.trimIndent(),
+            listOf("ab", "bc"),
             mutableListOf("db"),
             mutableListOf(
                 LongProblemUpsertRequestDto.GradingStandardData(


### PR DESCRIPTION
### Issue Number

close: N/A

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 서술형 모범 답안을 여러개로 저장할 수 있도록 어드민 API 수정

### 변경사항

- N/A

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항
