### PR TITLE
feat : 문제 랜덤하게 가져오는 로직 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -529,6 +529,38 @@ include::{snippets}/problems/search/request-parameters.adoc[]
 include::{snippets}/problems/search/response-body.adoc[]
 include::{snippets}/problems/search/response-fields.adoc[]
 
+
+=== 문제 랜덤 조회
+
+.description
+[source]
+----
+문제를 랜덤하게 가져오기 위한 API입니다.영
+
+HTTP Method : GET
+End-Point   : /api/v1/problems/shuffle
+Req Params  : size
+----
+
+.Sample Request
+include::{snippets}/problems/shuffle/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/problems/shuffle/http-response.adoc[]
+
+
+include::{snippets}/problems/shuffle/request-headers.adoc[]
+
+.Request parameters
+
+문제 랜덤 조회를 위한 request parameter의 설명입니다.
+include::{snippets}/problems/shuffle/request-parameters.adoc[]
+
+
+.Response Body
+include::{snippets}/problems/shuffle/response-body.adoc[]
+include::{snippets}/problems/shuffle/response-fields.adoc[]
+
 ==== 문제 채점 결과 평가 의견
 .description
 [source]

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
@@ -32,6 +32,8 @@ class ProblemController(
         @RequestParam("tags", required = false) tags: List<String>?,
         @RequestParam("type", required = false) type: List<String>?,
         @RequestParam("isGradable", required = false) isGradable: Boolean?,
+        @RequestParam("shuffle", defaultValue = "false", required = false) shuffle: Boolean?,
+        @RequestParam("seed", defaultValue = "42", required = false) seed: Long?,
         pageable: Pageable,
     ): ApiResponse<ProblemPageResponseDto> {
         var solvedBy: String? = null
@@ -41,8 +43,8 @@ class ProblemController(
                 ?: throw UnAuthorizedException(ErrorCode.FORBIDDEN, "사용자 권한이 없습니다.")
         }
 
-        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable)
-        val foundProblems = commonProblemService.findProblems(searchDto, pageable)
+        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable, shuffle, seed, pageable)
+        val foundProblems = commonProblemService.findProblems(searchDto)
 
         return ApiResponse.success(foundProblems)
     }

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
@@ -10,7 +10,6 @@ import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 import io.csbroker.apiserver.service.problem.CommonProblemService
-import org.springframework.data.domain.Pageable
 import org.springframework.security.core.userdetails.User
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -34,7 +33,8 @@ class ProblemController(
         @RequestParam("isGradable", required = false) isGradable: Boolean?,
         @RequestParam("shuffle", defaultValue = "false", required = false) shuffle: Boolean?,
         @RequestParam("seed", defaultValue = "42", required = false) seed: Long?,
-        pageable: Pageable,
+        @RequestParam("page") page: Int,
+        @RequestParam("size") size: Int,
     ): ApiResponse<ProblemPageResponseDto> {
         var solvedBy: String? = null
 
@@ -43,7 +43,7 @@ class ProblemController(
                 ?: throw UnAuthorizedException(ErrorCode.FORBIDDEN, "사용자 권한이 없습니다.")
         }
 
-        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable, shuffle, seed, pageable)
+        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable, shuffle, seed, page, size)
         val foundProblems = commonProblemService.findProblems(searchDto)
 
         return ApiResponse.success(foundProblems)

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemController.kt
@@ -8,6 +8,7 @@ import io.csbroker.apiserver.dto.common.ApiResponse
 import io.csbroker.apiserver.dto.common.UpsertSuccessResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
+import io.csbroker.apiserver.dto.problem.ProblemsResponseDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 import io.csbroker.apiserver.service.problem.CommonProblemService
 import org.springframework.security.core.userdetails.User
@@ -31,8 +32,6 @@ class ProblemController(
         @RequestParam("tags", required = false) tags: List<String>?,
         @RequestParam("type", required = false) type: List<String>?,
         @RequestParam("isGradable", required = false) isGradable: Boolean?,
-        @RequestParam("shuffle", defaultValue = "false", required = false) shuffle: Boolean?,
-        @RequestParam("seed", defaultValue = "42", required = false) seed: Long?,
         @RequestParam("page") page: Int,
         @RequestParam("size") size: Int,
     ): ApiResponse<ProblemPageResponseDto> {
@@ -43,10 +42,16 @@ class ProblemController(
                 ?: throw UnAuthorizedException(ErrorCode.FORBIDDEN, "사용자 권한이 없습니다.")
         }
 
-        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable, shuffle, seed, page, size)
+        val searchDto = ProblemSearchDto(tags, solvedBy, isSolved, query, type, isGradable, page, size)
         val foundProblems = commonProblemService.findProblems(searchDto)
 
         return ApiResponse.success(foundProblems)
+    }
+
+    @GetMapping("/shuffle")
+    fun getRandomProblems(@RequestParam("size") size: Int): ApiResponse<ProblemsResponseDto> {
+        val problemsResponseDto = commonProblemService.findRandomProblems(size)
+        return ApiResponse.success(problemsResponseDto)
     }
 
     @PostMapping("/grade/{id}/assessment")

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
@@ -7,8 +7,6 @@ data class ProblemSearchDto(
     val query: String?,
     val type: List<String>? = listOf(),
     val isGradable: Boolean?,
-    val shuffle: Boolean? = false,
-    val seed: Long? = 42,
     val page: Int,
     val size: Int,
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
@@ -1,7 +1,5 @@
 package io.csbroker.apiserver.dto.problem
 
-import org.springframework.data.domain.Pageable
-
 data class ProblemSearchDto(
     val tags: List<String>? = listOf(),
     val solvedBy: String?,
@@ -11,5 +9,6 @@ data class ProblemSearchDto(
     val isGradable: Boolean?,
     val shuffle: Boolean? = false,
     val seed: Long? = 42,
-    val pageable: Pageable,
+    val page: Int,
+    val size: Int,
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemSearchDto.kt
@@ -1,5 +1,7 @@
 package io.csbroker.apiserver.dto.problem
 
+import org.springframework.data.domain.Pageable
+
 data class ProblemSearchDto(
     val tags: List<String>? = listOf(),
     val solvedBy: String?,
@@ -7,4 +9,7 @@ data class ProblemSearchDto(
     val query: String?,
     val type: List<String>? = listOf(),
     val isGradable: Boolean?,
+    val shuffle: Boolean? = false,
+    val seed: Long? = 42,
+    val pageable: Pageable,
 )

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemsResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemsResponseDto.kt
@@ -1,3 +1,3 @@
 package io.csbroker.apiserver.dto.problem
 
-data class ProblemsResponseDto (val contents: List<ProblemResponseDto>)
+data class ProblemsResponseDto(val contents: List<ProblemResponseDto>)

--- a/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemsResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/dto/problem/ProblemsResponseDto.kt
@@ -1,0 +1,3 @@
+package io.csbroker.apiserver.dto.problem
+
+data class ProblemsResponseDto (val contents: List<ProblemResponseDto>)

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepository.kt
@@ -3,10 +3,15 @@ package io.csbroker.apiserver.repository.problem
 import io.csbroker.apiserver.model.Problem
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ProblemRepository : JpaRepository<Problem, Long>, ProblemRepositoryCustom {
     fun deleteProblemsByIdIn(ids: List<Long>)
 
     @Query("select count(p) from Problem p where p.isGradable = TRUE and p.isActive = TRUE")
     fun countGradableProblem(): Long
+
+    @Query("select problem_id from problem p order by RAND() limit :size", nativeQuery = true)
+    fun findRandomProblemIds(@Param(value = "size") size: Int): List<Long>
+
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepository.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepository.kt
@@ -13,5 +13,4 @@ interface ProblemRepository : JpaRepository<Problem, Long>, ProblemRepositoryCus
 
     @Query("select problem_id from problem p order by RAND() limit :size", nativeQuery = true)
     fun findRandomProblemIds(@Param(value = "size") size: Int): List<Long>
-
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
@@ -1,9 +1,12 @@
 package io.csbroker.apiserver.repository.problem
 
+import io.csbroker.apiserver.dto.problem.GradingHistoryStats
 import io.csbroker.apiserver.dto.problem.ProblemResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
+import io.csbroker.apiserver.model.Problem
 import org.springframework.data.domain.Page
 
 interface ProblemRepositoryCustom {
     fun findProblemsByQuery(problemSearchDto: ProblemSearchDto): Page<ProblemResponseDto>
+    fun getProblemId2StatMap(problems: List<Problem>): Map<Long?, GradingHistoryStats>
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Page
 
 interface ProblemRepositoryCustom {
     fun findProblemsByQuery(problemSearchDto: ProblemSearchDto): Page<ProblemResponseDto>
-    fun getProblemId2StatMap(problems: List<Problem>): Map<Long?, GradingHistoryStats>
+    fun getProblemIdToStatMap(problems: List<Problem>): Map<Long, GradingHistoryStats>
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustom.kt
@@ -3,8 +3,7 @@ package io.csbroker.apiserver.repository.problem
 import io.csbroker.apiserver.dto.problem.ProblemResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 interface ProblemRepositoryCustom {
-    fun findProblemsByQuery(problemSearchDto: ProblemSearchDto, pageable: Pageable): Page<ProblemResponseDto>
+    fun findProblemsByQuery(problemSearchDto: ProblemSearchDto): Page<ProblemResponseDto>
 }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
@@ -36,7 +36,6 @@ class ProblemRepositoryCustomImpl(
         )
     }
 
-
     private fun getPaginatedIds(problemSearchDto: ProblemSearchDto, pageable: Pageable): List<Long> {
         val ids = queryFactory.select(problem.id)
             .from(problem)

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
@@ -14,16 +14,18 @@ import io.csbroker.apiserver.model.QTag.tag
 import io.csbroker.apiserver.model.QUser.user
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import java.util.Random
+import kotlin.random.Random
 
 class ProblemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory,
 ) : ProblemRepositoryCustom {
 
     override fun findProblemsByQuery(problemSearchDto: ProblemSearchDto): Page<ProblemResponseDto> {
+        val pageable = PageRequest.of(problemSearchDto.page, problemSearchDto.size)
         val totalProblemIds = getTotalProblemIdsWithFiltering(problemSearchDto)
-        val ids = getPaginatedIds(totalProblemIds, problemSearchDto.pageable)
+        val ids = getPaginatedIds(totalProblemIds, pageable)
         val problems = getProblemsWithFetchJoin(ids)
         val gradingHistories = getGradingHistoriesRelatedProblems(problems)
         val stats = getStats(gradingHistories)
@@ -32,7 +34,7 @@ class ProblemRepositoryCustomImpl(
             problems.map {
                 it.toProblemResponseDto(stats[it.id])
             },
-            problemSearchDto.pageable,
+            pageable,
             totalProblemIds.size.toLong(),
         )
     }

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
@@ -15,7 +15,7 @@ import io.csbroker.apiserver.model.QUser.user
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import java.util.*
+import java.util.Random
 
 class ProblemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory,

--- a/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/repository/problem/ProblemRepositoryCustomImpl.kt
@@ -25,11 +25,11 @@ class ProblemRepositoryCustomImpl(
         val pageable = PageRequest.of(problemSearchDto.page, problemSearchDto.size)
         val ids = getPaginatedIds(problemSearchDto, pageable)
         val problems = getProblemsWithFetchJoin(ids)
-        val stats = getProblemId2StatMap(problems)
+        val problemIdToStatMap = getProblemIdToStatMap(problems)
         val totalProblemSize = getTotalProblemSize(problemSearchDto)
         return PageImpl(
             problems.map {
-                it.toProblemResponseDto(stats[it.id])
+                it.toProblemResponseDto(problemIdToStatMap[it.id])
             },
             pageable,
             totalProblemSize,
@@ -70,10 +70,10 @@ class ProblemRepositoryCustomImpl(
             .orderBy(problem.createdAt.desc())
             .fetch()
 
-    override fun getProblemId2StatMap(problems: List<Problem>): Map<Long?, GradingHistoryStats> =
+    override fun getProblemIdToStatMap(problems: List<Problem>): Map<Long, GradingHistoryStats> =
         getGradingHistoriesRelatedProblems(problems)
             .groupBy {
-                it.problem.id
+                it.problem.id!!
             }.map {
                 it.key to GradingHistoryStats.toGradingHistoryStats(it.value)
             }.toMap()

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemService.kt
@@ -2,11 +2,13 @@ package io.csbroker.apiserver.service.problem
 
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
+import io.csbroker.apiserver.dto.problem.ProblemsResponseDto
 import io.csbroker.apiserver.dto.problem.challenge.CreateChallengeDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 
 interface CommonProblemService {
     fun findProblems(problemSearchDto: ProblemSearchDto): ProblemPageResponseDto
+    fun findRandomProblems(size: Int): ProblemsResponseDto
     fun removeProblemById(id: Long)
     fun removeProblemsById(ids: List<Long>)
     fun gradingAssessment(email: String, gradingHistoryId: Long, assessmentRequestDto: AssessmentRequestDto): Long

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemService.kt
@@ -4,10 +4,9 @@ import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
 import io.csbroker.apiserver.dto.problem.challenge.CreateChallengeDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
-import org.springframework.data.domain.Pageable
 
 interface CommonProblemService {
-    fun findProblems(problemSearchDto: ProblemSearchDto, pageable: Pageable): ProblemPageResponseDto
+    fun findProblems(problemSearchDto: ProblemSearchDto): ProblemPageResponseDto
     fun removeProblemById(id: Long)
     fun removeProblemsById(ids: List<Long>)
     fun gradingAssessment(email: String, gradingHistoryId: Long, assessmentRequestDto: AssessmentRequestDto): Long

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
@@ -35,10 +35,10 @@ class CommonProblemServiceImpl(
     override fun findRandomProblems(size: Int): ProblemsResponseDto {
         val problemIds = problemRepository.findRandomProblemIds(size)
         val problems = problemRepository.findAllById(problemIds)
-        val statMap = problemRepository.getProblemId2StatMap(problems)
+        val problemIdToStatMap = problemRepository.getProblemIdToStatMap(problems)
         return ProblemsResponseDto(
             problems.map {
-                it.toProblemResponseDto(statMap[it.id])
+                it.toProblemResponseDto(problemIdToStatMap[it.id])
             },
         )
     }

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
@@ -6,6 +6,7 @@ import io.csbroker.apiserver.common.exception.EntityNotFoundException
 import io.csbroker.apiserver.common.exception.UnAuthorizedException
 import io.csbroker.apiserver.dto.problem.ProblemPageResponseDto
 import io.csbroker.apiserver.dto.problem.ProblemSearchDto
+import io.csbroker.apiserver.dto.problem.ProblemsResponseDto
 import io.csbroker.apiserver.dto.problem.challenge.CreateChallengeDto
 import io.csbroker.apiserver.dto.problem.grade.AssessmentRequestDto
 import io.csbroker.apiserver.model.Challenge
@@ -29,6 +30,17 @@ class CommonProblemServiceImpl(
 ) : CommonProblemService {
     override fun findProblems(problemSearchDto: ProblemSearchDto): ProblemPageResponseDto {
         return ProblemPageResponseDto(problemRepository.findProblemsByQuery(problemSearchDto))
+    }
+
+    override fun findRandomProblems(size: Int): ProblemsResponseDto {
+        val problemIds = problemRepository.findRandomProblemIds(size)
+        val problems = problemRepository.findAllById(problemIds)
+        val statMap = problemRepository.getProblemId2StatMap(problems)
+        return ProblemsResponseDto(
+            problems.map {
+                it.toProblemResponseDto(statMap[it.id])
+            }
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
@@ -14,7 +14,6 @@ import io.csbroker.apiserver.repository.problem.GradingHistoryRepository
 import io.csbroker.apiserver.repository.problem.GradingResultAssessmentRepository
 import io.csbroker.apiserver.repository.problem.ProblemRepository
 import io.csbroker.apiserver.repository.user.UserRepository
-import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,8 +27,8 @@ class CommonProblemServiceImpl(
     private val userRepository: UserRepository,
     private val challengeRepository: ChallengeRepository,
 ) : CommonProblemService {
-    override fun findProblems(problemSearchDto: ProblemSearchDto, pageable: Pageable): ProblemPageResponseDto {
-        return ProblemPageResponseDto(problemRepository.findProblemsByQuery(problemSearchDto, pageable))
+    override fun findProblems(problemSearchDto: ProblemSearchDto): ProblemPageResponseDto {
+        return ProblemPageResponseDto(problemRepository.findProblemsByQuery(problemSearchDto))
     }
 
     @Transactional

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/CommonProblemServiceImpl.kt
@@ -39,7 +39,7 @@ class CommonProblemServiceImpl(
         return ProblemsResponseDto(
             problems.map {
                 it.toProblemResponseDto(statMap[it.id])
-            }
+            },
         )
     }
 

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemControllerTest.kt
@@ -29,7 +29,6 @@ import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.requestParameters
-import kotlin.random.Random
 
 class ProblemControllerTest : RestDocsTest() {
     private lateinit var mockMvc: MockMvcRequestSpecification
@@ -150,8 +149,8 @@ class ProblemControllerTest : RestDocsTest() {
                     avgScore = 2.0,
                     totalSubmission = 20,
                     type = "long",
-                )
-            )
+                ),
+            ),
         )
 
         // when
@@ -188,8 +187,8 @@ class ProblemControllerTest : RestDocsTest() {
                             .description("총 제출 수"),
                         fieldWithPath("data.contents.[].type").type(JsonFieldType.STRING)
                             .description("문제의 타입 ( short, multiple, long )"),
-                    )
-                )
+                    ),
+                ),
             )
     }
 

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/ProblemControllerTest.kt
@@ -53,7 +53,10 @@ class ProblemControllerTest : RestDocsTest() {
         val size = 10
         val type = "long"
         val isGradable = false
-        every { commonProblemService.findProblems(any(), any()) } returns ProblemPageResponseDto(
+        val shuffle = true
+        val seed = 42L
+
+        every { commonProblemService.findProblems(any()) } returns ProblemPageResponseDto(
             PageImpl(
                 listOf(
                     ProblemResponseDto(
@@ -74,7 +77,7 @@ class ProblemControllerTest : RestDocsTest() {
         val result = mockMvc.request(
             Method.GET,
             "/api/v1/problems?query=$query&isSolved=$isSolved&tags=$tags" +
-                "&page=$page&size=$size&type=$type&isGradable=$isGradable",
+                "&page=$page&size=$size&type=$type&isGradable=$isGradable&shuffle=$shuffle&seed=$seed",
         )
         // then
         result.then()
@@ -97,6 +100,8 @@ class ProblemControllerTest : RestDocsTest() {
                         parameterWithName("size").description("가져올 문제의 개수"),
                         parameterWithName("type").description("문제의 type ( long, short, multiple )"),
                         parameterWithName("isGradable").description("채점 가능 여부"),
+                        parameterWithName("shuffle").description("문제 셔플링 여부"),
+                        parameterWithName("seed").description("랜덤 시드"),
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("결과 상태"),


### PR DESCRIPTION
문제 랜덤 추출 QueryParams 추가 및 메서드 분리

### Issue Number

close: MSTR-413

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 문제 검색시 쿼리파람으로 shuffle flag와 랜덤 시드를 입력받을 수 있도록 추가 (메인 페이지, 모든 문제 보기에서 활용 가능)
- [x] findProblemsByQuery 메서드 분리

### 변경사항

- 의존성 목록

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- default 값으로 `shuffle = false`, `seed = 42 `로 설정해놨습니다.
- `shuffle=false` 일 때 가장 최근에 생성된 문제가 먼저 보이도록 ordering을 해놓았습니다.

