### PR TITLE
feat : 서술형 채점하지 않고 제출 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -367,7 +367,6 @@ include::{snippets}/problems/long/grade/http-response.adoc[]
 .Path parameters
 include::{snippets}/problems/long/grade/path-parameters.adoc[]
 
-서술형 문제 단건 조회를 위한 path parameter의 설명입니다.
 
 .Request Header
 request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
@@ -379,6 +378,41 @@ include::{snippets}/problems/long/grade/request-parameters.adoc[]
 .Response Body
 include::{snippets}/problems/long/grade/response-body.adoc[]
 include::{snippets}/problems/long/grade/response-fields.adoc[]
+
+
+=== 서술형 문제 제출 (채점 X)
+.description
+[source]
+----
+서술형 문제 제출을 위한 API 입니다.
+
+HTTP Method : POST
+End-Point   : /api/v1/problems/long/{problem_id:Long}/submit
+
+----
+
+.Sample Request
+include::{snippets}/problems/long/submit/http-request.adoc[]
+
+.Sample Response
+include::{snippets}/problems/long/submit/http-response.adoc[]
+
+.Path parameters
+include::{snippets}/problems/long/submit/path-parameters.adoc[]
+
+
+.Request Header
+request를 살펴보면 Authorization 헤더에서 Bearer token 형태로, access token을 전달하는 것을 알 수 있습니다.
+include::{snippets}/problems/long/submit/request-headers.adoc[]
+
+.Request Params
+include::{snippets}/problems/long/submit/request-parameters.adoc[]
+
+.Response Body
+include::{snippets}/problems/long/submit/response-body.adoc[]
+include::{snippets}/problems/long/submit/response-fields.adoc[]
+
+
 
 ==== 단답형 문제 단건 조회
 

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemController.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemController.kt
@@ -2,6 +2,8 @@ package io.csbroker.apiserver.controller.v1.problem
 
 import io.csbroker.apiserver.auth.LoginUser
 import io.csbroker.apiserver.common.util.getEmailFromSecurityContextHolder
+import io.csbroker.apiserver.controller.v2.problem.request.SubmitLongProblemDto
+import io.csbroker.apiserver.controller.v2.problem.response.SubmitLongProblemResponseDto
 import io.csbroker.apiserver.dto.common.ApiResponse
 import io.csbroker.apiserver.dto.problem.grade.LongProblemGradingRequestDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemAnswerDto
@@ -44,5 +46,16 @@ class LongProblemController(
         )
         val gradeHistory = longProblemService.gradingProblem(gradingRequestDto)
         return ApiResponse.success(gradeHistory)
+    }
+
+    @PostMapping("{id}/submit")
+    fun submitLongProblem(
+        @LoginUser user: User,
+        @PathVariable("id") problemId: Long,
+        @RequestBody answerDto: LongProblemAnswerDto,
+    ): ApiResponse<SubmitLongProblemResponseDto> {
+        val submitRequestDto = SubmitLongProblemDto(user.username, problemId, answerDto.answer)
+        val submitResponseDto = longProblemService.submitProblem(submitRequestDto)
+        return ApiResponse.success(submitResponseDto)
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/request/SubmitLongProblemDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/request/SubmitLongProblemDto.kt
@@ -1,0 +1,8 @@
+package io.csbroker.apiserver.controller.v2.problem.request
+
+
+data class SubmitLongProblemDto(
+    val email: String,
+    val problemId: Long,
+    val answer: String,
+)

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/request/SubmitLongProblemDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/request/SubmitLongProblemDto.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.controller.v2.problem.request
 
-
 data class SubmitLongProblemDto(
     val email: String,
     val problemId: Long,

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/response/SubmitLongProblemResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/response/SubmitLongProblemResponseDto.kt
@@ -1,6 +1,5 @@
 package io.csbroker.apiserver.controller.v2.problem.response
 
-
 data class SubmitLongProblemResponseDto(
     val title: String,
     val tags: List<String>,

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/response/SubmitLongProblemResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v2/problem/response/SubmitLongProblemResponseDto.kt
@@ -1,0 +1,12 @@
+package io.csbroker.apiserver.controller.v2.problem.response
+
+
+data class SubmitLongProblemResponseDto(
+    val title: String,
+    val tags: List<String>,
+    val description: String,
+    val totalSubmissionCount: Int,
+    val userSubmissionCount: Int,
+    val userAnswer: String,
+    val standardAnswer: String,
+)

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemService.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemService.kt
@@ -1,5 +1,7 @@
 package io.csbroker.apiserver.service.problem
 
+import io.csbroker.apiserver.controller.v2.problem.request.SubmitLongProblemDto
+import io.csbroker.apiserver.controller.v2.problem.response.SubmitLongProblemResponseDto
 import io.csbroker.apiserver.dto.problem.grade.LongProblemGradingRequestDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemDetailResponseDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemGradingHistoryDto
@@ -7,4 +9,5 @@ import io.csbroker.apiserver.dto.problem.longproblem.LongProblemGradingHistoryDt
 interface LongProblemService {
     fun findProblemById(id: Long, email: String?): LongProblemDetailResponseDto
     fun gradingProblem(gradingRequest: LongProblemGradingRequestDto): LongProblemGradingHistoryDto
+    fun submitProblem(submitRequest: SubmitLongProblemDto): SubmitLongProblemResponseDto
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
@@ -152,12 +152,10 @@ class LongProblemServiceImpl(
         val userAnswer = UserAnswer(answer = answer, problem = problem)
         userAnswerRepository.save(userAnswer)
 
-        val standardAnswer = standardAnswerRepository.findAllByLongProblem(problem).let {
-            if (it.isEmpty()) {
-                throw EntityNotFoundException("{$problem.id}번 문제에 대한 모범답안이 존재하지 않습니다.")
-            }
-            it.random().content
-        }
+        val standardAnswer = standardAnswerRepository.findAllByLongProblem(problem).takeIf {
+            it.isNotEmpty()
+        }?.random()?.content ?: throw EntityNotFoundException("{$problem.id}번 문제에 대한 모범답안이 존재하지 않습니다.")
+
         val tags = problem.problemTags.map {
             it.tag.name
         }

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
@@ -7,6 +7,8 @@ import io.csbroker.apiserver.common.enums.GradingStandardType
 import io.csbroker.apiserver.common.exception.EntityNotFoundException
 import io.csbroker.apiserver.common.exception.InternalServiceException
 import io.csbroker.apiserver.common.util.log
+import io.csbroker.apiserver.controller.v2.problem.request.SubmitLongProblemDto
+import io.csbroker.apiserver.controller.v2.problem.response.SubmitLongProblemResponseDto
 import io.csbroker.apiserver.dto.problem.grade.GradeResultDto
 import io.csbroker.apiserver.dto.problem.grade.KeywordGradingRequestDto
 import io.csbroker.apiserver.dto.problem.grade.LongProblemGradingRequestDto
@@ -135,6 +137,43 @@ class LongProblemServiceImpl(
             keywords = correctKeywordListDto + notCorrectKeywordListDto,
             contents = correctContentListDto + notCorrectContentListDto,
             standardAnswer = standardAnswers.random(),
+        )
+    }
+
+    @Transactional
+    override fun submitProblem(submitRequest: SubmitLongProblemDto): SubmitLongProblemResponseDto {
+        val (email, problemId, answer) = submitRequest
+        val user = userRepository.findByEmail(email)
+            ?: throw EntityNotFoundException("$email 을 가진 유저는 존재하지 않습니다.")
+
+        val problem = longProblemRepository.findByIdOrNull(problemId)
+            ?: throw EntityNotFoundException("${problemId}번 문제는 존재하지 않는 서술형 문제입니다.")
+
+        val userAnswer = UserAnswer(answer = answer, problem = problem)
+        userAnswerRepository.save(userAnswer)
+
+        val standardAnswer = standardAnswerRepository.findAllByLongProblem(problem).let {
+            if (it.isEmpty())
+                throw EntityNotFoundException("{$problem.id}번 문제에 대한 모범답안이 존재하지 않습니다.")
+            it.random().content
+        }
+        val tags = problem.problemTags.map{
+            it.tag.name
+        }
+        val gradingHistories = problem.gradingHistory
+        val totalSubmissionCount = gradingHistories.size
+        val userSubmissionCount = gradingHistories.filter{
+            it.user.id == user.id
+        }.size
+
+        return SubmitLongProblemResponseDto(
+            title = problem.title,
+            tags = tags,
+            description = problem.description,
+            totalSubmissionCount = totalSubmissionCount,
+            userSubmissionCount = userSubmissionCount,
+            userAnswer = answer,
+            standardAnswer = standardAnswer
         )
     }
 

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
@@ -163,9 +163,7 @@ class LongProblemServiceImpl(
         }
         val gradingHistories = problem.gradingHistory
         val totalSubmissionCount = gradingHistories.size
-        val userSubmissionCount = gradingHistories.filter {
-            it.user.id == user.id
-        }.size
+        val userSubmissionCount = gradingHistories.count { it.user.id == user.id }
 
         return SubmitLongProblemResponseDto(
             title = problem.title,

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/LongProblemServiceImpl.kt
@@ -153,16 +153,17 @@ class LongProblemServiceImpl(
         userAnswerRepository.save(userAnswer)
 
         val standardAnswer = standardAnswerRepository.findAllByLongProblem(problem).let {
-            if (it.isEmpty())
+            if (it.isEmpty()) {
                 throw EntityNotFoundException("{$problem.id}번 문제에 대한 모범답안이 존재하지 않습니다.")
+            }
             it.random().content
         }
-        val tags = problem.problemTags.map{
+        val tags = problem.problemTags.map {
             it.tag.name
         }
         val gradingHistories = problem.gradingHistory
         val totalSubmissionCount = gradingHistories.size
-        val userSubmissionCount = gradingHistories.filter{
+        val userSubmissionCount = gradingHistories.filter {
             it.user.id == user.id
         }.size
 
@@ -173,7 +174,7 @@ class LongProblemServiceImpl(
             totalSubmissionCount = totalSubmissionCount,
             userSubmissionCount = userSubmissionCount,
             userAnswer = answer,
-            standardAnswer = standardAnswer
+            standardAnswer = standardAnswer,
         )
     }
 

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemControllerTest.kt
@@ -234,6 +234,7 @@ class LongProblemControllerTest : RestDocsTest() {
                         fieldWithPath("answer").type(JsonFieldType.STRING).description("유저가 작성한 답안"),
                     ),
                     responseFields(
+                        fieldWithPath("status").type(JsonFieldType.STRING).description("결과 상태"),
                         fieldWithPath("data.title").type(JsonFieldType.STRING).description("문제 제목"),
                         fieldWithPath("data.tags").type(JsonFieldType.ARRAY).description("태그"),
                         fieldWithPath("data.description").type(JsonFieldType.STRING).description("문제 설명"),

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/problem/LongProblemControllerTest.kt
@@ -1,6 +1,7 @@
 package io.csbroker.apiserver.controller.v1.problem
 
 import io.csbroker.apiserver.controller.RestDocsTest
+import io.csbroker.apiserver.controller.v2.problem.response.SubmitLongProblemResponseDto
 import io.csbroker.apiserver.dto.problem.longproblem.ContentDto
 import io.csbroker.apiserver.dto.problem.longproblem.KeywordDto
 import io.csbroker.apiserver.dto.problem.longproblem.LongProblemAnswerDto
@@ -22,6 +23,7 @@ import org.springframework.restdocs.operation.preprocess.Preprocessors.preproces
 import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
@@ -186,6 +188,61 @@ class LongProblemControllerTest : RestDocsTest() {
                             .description("내용 채점 기준 내용"),
                         fieldWithPath("data.contents.[].isExist").type(JsonFieldType.BOOLEAN)
                             .description("내용 채점 기준이 유저답안에 존재하는지 유무"),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    fun `서술형 문제 제출`() {
+        // given
+        val responseDto = SubmitLongProblemResponseDto(
+            title = "title",
+            tags = listOf("tag1", "tag2", "tag3"),
+            description = "description",
+            totalSubmissionCount = 100,
+            userSubmissionCount = 10,
+            userAnswer = "user answer",
+            standardAnswer = "standard answer",
+        )
+        every { longProblemService.submitProblem(any()) } returns responseDto
+
+        // when
+
+        val result = mockMvc.body(
+            LongProblemAnswerDto(
+                answer = "user answer",
+            ),
+        ).request(Method.POST, "/api/v1/problems/long/{problem_id}/submit", 1L)
+
+        result.then()
+            .statusCode(200)
+            .apply(
+                document(
+                    "problems/long/submit",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION)
+                            .description("인증을 위한 Access 토큰")
+                            .optional(),
+                    ),
+                    pathParameters(
+                        parameterWithName("problem_id").description("문제 id"),
+                    ),
+                    requestFields(
+                        fieldWithPath("answer").type(JsonFieldType.STRING).description("유저가 작성한 답안"),
+                    ),
+                    responseFields(
+                        fieldWithPath("data.title").type(JsonFieldType.STRING).description("문제 제목"),
+                        fieldWithPath("data.tags").type(JsonFieldType.ARRAY).description("태그"),
+                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("문제 설명"),
+                        fieldWithPath("data.totalSubmissionCount").type(JsonFieldType.NUMBER)
+                            .description("해당 문제에 대해 전체 유저가 제출한 수 (총 제출 수)"),
+                        fieldWithPath("data.userSubmissionCount").type(JsonFieldType.NUMBER)
+                            .description("해당 문제에 대해 유저가 제출한 수 "),
+                        fieldWithPath("data.userAnswer").type(JsonFieldType.STRING).description("유저의 답변"),
+                        fieldWithPath("data.standardAnswer").type(JsonFieldType.STRING).description("모범 답안"),
                     ),
                 ),
             )


### PR DESCRIPTION
### Issue Number

close: MSTR-411

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 서술형 답안 제출 기능 추가

### 변경사항

- 의존성 목록

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 서술형 채점이 사라지면서 제출 기능만 추가하였습니다.
- `LongProblemControllerV2`에 추가를 할까 고민을 했지만 생각해보니 이제 채점이 아니라 제출의 개념이라는 생각이 들어 submit이라는 API를 새로 만들었습니다.
- 서술형 채점이 사라지면서 서술형 문제있는 점수 관련된 내용들이 필요가 없어지게 되었습니다. (아래 사진 참고) 그래서 총 제출수는 살리고 내가 제출한 수를 response에 추가해주었습니다.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/67869514/235311845-77daa7f8-fe67-4610-99a0-b90911ee06d2.png">


