### PR TITLE
feat : post와 comment 응답에 user id를 포함하도록 수정

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/post/response/CommentResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/post/response/CommentResponseDto.kt
@@ -2,11 +2,13 @@ package io.csbroker.apiserver.controller.v1.post.response
 
 import io.csbroker.apiserver.model.Comment
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CommentResponseDto(
     val id: Long,
     val content: String,
     val username: String,
+    val userId: UUID,
     val likeCount: Long,
     val isLiked: Boolean,
     val createdAt: LocalDateTime,
@@ -14,6 +16,7 @@ data class CommentResponseDto(
     constructor(comment: Comment, likeCount: Long, isLiked: Boolean) : this(
         id = comment.id,
         content = comment.content,
+        userId = comment.user.id!!,
         username = comment.user.username,
         likeCount = likeCount,
         isLiked = isLiked,

--- a/src/main/kotlin/io/csbroker/apiserver/controller/v1/post/response/PostResponseDto.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/controller/v1/post/response/PostResponseDto.kt
@@ -1,11 +1,13 @@
 package io.csbroker.apiserver.controller.v1.post.response
 
 import io.csbroker.apiserver.model.Post
+import java.util.UUID
 
 data class PostResponseDto(
     val id: Long,
     val content: String,
     val username: String,
+    val userId: UUID,
     val likeCount: Long,
     val isLiked: Boolean,
     val comments: List<CommentResponseDto>,
@@ -13,9 +15,10 @@ data class PostResponseDto(
     constructor(post: Post, likeCount: Long, isLiked: Boolean, comments: List<CommentResponseDto>) : this(
         id = post.id,
         content = post.content,
+        userId = post.user.id!!,
         username = post.user.username,
         likeCount = likeCount,
         isLiked = isLiked,
-        comments = comments,
+        comments = comments.sortedBy { it.createdAt },
     )
 }

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/post/PostControllerTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/post/PostControllerTest.kt
@@ -18,6 +18,7 @@ import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.request.RequestDocumentation
 import java.time.LocalDateTime
+import java.util.UUID
 
 class PostControllerTest : RestDocsTest() {
     private lateinit var postService: PostService
@@ -101,6 +102,7 @@ class PostControllerTest : RestDocsTest() {
                 1L,
                 "CONTENT",
                 "USER",
+                UUID.randomUUID(),
                 1,
                 true,
                 listOf(
@@ -108,6 +110,7 @@ class PostControllerTest : RestDocsTest() {
                         1L,
                         "CONTENT",
                         "USER",
+                        UUID.randomUUID(),
                         1,
                         true,
                         LocalDateTime.now(),
@@ -138,6 +141,8 @@ class PostControllerTest : RestDocsTest() {
                             .type(JsonFieldType.STRING).description("글 내용"),
                         PayloadDocumentation.fieldWithPath("data[].username")
                             .type(JsonFieldType.STRING).description("작성자"),
+                        PayloadDocumentation.fieldWithPath("data[].userId")
+                            .type(JsonFieldType.STRING).description("작성자 ID"),
                         PayloadDocumentation.fieldWithPath("data[].likeCount")
                             .type(JsonFieldType.NUMBER).description("좋아요 수"),
                         PayloadDocumentation.fieldWithPath("data[].isLiked")
@@ -148,6 +153,8 @@ class PostControllerTest : RestDocsTest() {
                             .type(JsonFieldType.STRING).description("댓글 내용"),
                         PayloadDocumentation.fieldWithPath("data[].comments[].username")
                             .type(JsonFieldType.STRING).description("댓글 작성자"),
+                        PayloadDocumentation.fieldWithPath("data[].comments[].userId")
+                            .type(JsonFieldType.STRING).description("댓글 작성자 ID"),
                         PayloadDocumentation.fieldWithPath("data[].comments[].likeCount")
                             .type(JsonFieldType.NUMBER).description("좋아요 수"),
                         PayloadDocumentation.fieldWithPath("data[].comments[].isLiked")


### PR DESCRIPTION
### Issue Number

close: # N/A

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] post와 comment 응답에 user id를 포함하도록 수정
- [x] comment 응답을 생성시간 오름차순으로 전달하도록 수정

### 변경사항

- 의존성 목록

### 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- related with https://github.com/SW13-Monstera/frontend/pull/114

