### PR TITLE
fix: StandardAnswer 업데이트시 기존 StandardAnswer 삭제 안 되던 버그 수정

### DIFF
--- a/src/main/kotlin/io/csbroker/apiserver/model/LongProblem.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/model/LongProblem.kt
@@ -25,7 +25,7 @@ class LongProblem(
     @OneToMany(mappedBy = "problem", cascade = [CascadeType.ALL])
     var userAnswers: MutableList<UserAnswer> = mutableListOf(),
 
-    @OneToMany(mappedBy = "longProblem", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "longProblem", cascade = [CascadeType.ALL], orphanRemoval = true)
     var standardAnswers: MutableList<StandardAnswer> = mutableListOf(),
 ) : Problem(
     title = title,
@@ -45,6 +45,7 @@ class LongProblem(
         description = upsertRequestDto.description
         isGradable = upsertRequestDto.isGradable
         isActive = upsertRequestDto.isActive
+        updateStandardAnswers(upsertRequestDto.standardAnswers)
     }
 
     fun toLongProblemResponseDto(): LongProblemResponseDto {
@@ -110,5 +111,19 @@ class LongProblem(
             likes.any { it.user.email == email },
             problemBookmark.any { it.user.email == email },
         )
+    }
+
+    fun updateStandardAnswers(standardAnswers: List<String>) {
+        if (this.standardAnswers.map { it.content }.toSet() != standardAnswers.toSet()) {
+            this.standardAnswers.clear()
+            this.standardAnswers.addAll(
+                standardAnswers.map {
+                    StandardAnswer(
+                        content = it,
+                        longProblem = this,
+                    )
+                },
+            )
+        }
     }
 }

--- a/src/main/kotlin/io/csbroker/apiserver/service/problem/admin/AdminLongProblemServiceImpl.kt
+++ b/src/main/kotlin/io/csbroker/apiserver/service/problem/admin/AdminLongProblemServiceImpl.kt
@@ -71,18 +71,6 @@ class AdminLongProblemServiceImpl(
             ?: throw EntityNotFoundException("${id}번 문제는 존재하지 않는 서술형 문제입니다.")
         val gradingStandardList = updateRequestDto.getGradingStandardList(longProblem)
 
-        if (longProblem.standardAnswers.map { it.content }.toSet() != updateRequestDto.standardAnswers.toSet()) {
-            standardAnswerRepository.deleteAllByLongProblem(longProblem)
-            standardAnswerRepository.saveAll(
-                updateRequestDto.standardAnswers.map {
-                    StandardAnswer(
-                        content = it,
-                        longProblem = longProblem,
-                    )
-                },
-            )
-        }
-
         if (longProblem.gradingStandards.map { it.content }.toSet() != gradingStandardList.map { it.content }.toSet()) {
             gradingStandardRepository.deleteAllById(longProblem.gradingStandards.map { it.id })
             longProblem.addGradingStandards(gradingStandardList)

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/admin/problem/AdminLongProblemControllerIntegrationTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/admin/problem/AdminLongProblemControllerIntegrationTest.kt
@@ -1,0 +1,52 @@
+package io.csbroker.apiserver.controller.v1.admin.problem
+
+import io.csbroker.apiserver.controller.IntegrationTest
+import io.csbroker.apiserver.dto.problem.longproblem.LongProblemUpsertRequestDto
+import io.csbroker.apiserver.model.LongProblem
+import io.csbroker.apiserver.model.StandardAnswer
+import io.csbroker.apiserver.model.Tag
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class AdminLongProblemControllerIntegrationTest : IntegrationTest() {
+
+    @Test
+    fun `문제 업데이트`() {
+        // given
+        val problem = save(
+            LongProblem(
+                title = "문제 제목",
+                description = "문제 설명",
+                creator = adminUser,
+            ),
+        )
+        save(StandardAnswer(content = "삭제될 모범 답안", longProblem = problem))
+        save(Tag(name="tag1"))
+        val updateRequestDto = LongProblemUpsertRequestDto(
+            title = "Test problem",
+            description = "This is a test problem",
+            tags = mutableListOf("tag1"),
+            standardAnswers = listOf("업데이트될 모범 답안"),
+            gradingStandards = mutableListOf(),
+        )
+
+        // when
+        val response = request(
+            method = HttpMethod.PUT,
+            url = "/api/admin/problems/long/${problem.id}",
+            isAdmin = true,
+            body = updateRequestDto,
+        )
+
+        // then
+        response.andExpect(status().isOk)
+            .andExpect {
+                val standardAnswers = findAll<StandardAnswer>("SELECT s FROM StandardAnswer s where s.longProblem.id = :id", mapOf("id" to problem.id))
+                standardAnswers.map { it.content }.toSet() shouldBe updateRequestDto.standardAnswers.toSet()
+            }
+
+    }
+}

--- a/src/test/kotlin/io/csbroker/apiserver/controller/v1/admin/problem/AdminLongProblemControllerIntegrationTest.kt
+++ b/src/test/kotlin/io/csbroker/apiserver/controller/v1/admin/problem/AdminLongProblemControllerIntegrationTest.kt
@@ -7,7 +7,6 @@ import io.csbroker.apiserver.model.StandardAnswer
 import io.csbroker.apiserver.model.Tag
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-
 import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -24,7 +23,7 @@ class AdminLongProblemControllerIntegrationTest : IntegrationTest() {
             ),
         )
         save(StandardAnswer(content = "삭제될 모범 답안", longProblem = problem))
-        save(Tag(name="tag1"))
+        save(Tag(name = "tag1"))
         val updateRequestDto = LongProblemUpsertRequestDto(
             title = "Test problem",
             description = "This is a test problem",
@@ -44,9 +43,11 @@ class AdminLongProblemControllerIntegrationTest : IntegrationTest() {
         // then
         response.andExpect(status().isOk)
             .andExpect {
-                val standardAnswers = findAll<StandardAnswer>("SELECT s FROM StandardAnswer s where s.longProblem.id = :id", mapOf("id" to problem.id))
+                val standardAnswers = findAll<StandardAnswer>(
+                    "SELECT s FROM StandardAnswer s where s.longProblem.id = :id",
+                    mapOf("id" to problem.id),
+                )
                 standardAnswers.map { it.content }.toSet() shouldBe updateRequestDto.standardAnswers.toSet()
             }
-
     }
 }


### PR DESCRIPTION
### Issue Number

close: #

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 관리자페이지에서 서술형 문제 수정시 모범 답안이 정상적으로 업데이트되지 않던 버그 수정

### 변경사항

- 의존성 목록

### 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### PR 특이 사항

> 기존에 로직에서 StandardAnswer를 삭제시 LongProblem과 연관관계가 있는 StandardAnswer가 삭제되지 않는 버그가 존재했는데 원인은 정확하게 파악하지 못 했어요.
유추하기론 Relationship에 영향때문에 delete 명령어가 제대로 들어가지 않은 것 같은데 기존에 왜 삭제가 안 되었을지 아시면 알려주세요 🙏

